### PR TITLE
Make HLS live offset adapt per channel

### DIFF
--- a/app/src/main/java/app/opentv/player/AdaptiveLivePolicy.kt
+++ b/app/src/main/java/app/opentv/player/AdaptiveLivePolicy.kt
@@ -1,0 +1,31 @@
+/*
+ * This file is part of OpenTV.
+ * Copyright (C) 2026 The OpenTV Contributors
+ * Licensed under the GNU General Public License v3.0 or later.
+ */
+package app.opentv.player
+
+/**
+ * Conservative per-channel live tuning for bursty HLS feeds.
+ *
+ * A channel that still rebuffers moves one step farther from the live edge, and the caller
+ * persists that learned value for its next tune. The cap prevents a broken feed from accumulating
+ * unbounded delay.
+ */
+internal object AdaptiveLivePolicy {
+    const val DEFAULT_TARGET_MILLIS = 30_000L
+    const val REBUFFER_STEP_MILLIS = 5_000L
+    const val MAX_TARGET_MILLIS = 60_000L
+
+    fun appliesTo(isLive: Boolean, url: String): Boolean =
+        isLive && url.substringBefore('?').endsWith(".m3u8", ignoreCase = true)
+
+    fun targetFor(savedTargetMillis: Long?): Long =
+        savedTargetMillis
+            ?.coerceIn(DEFAULT_TARGET_MILLIS, MAX_TARGET_MILLIS)
+            ?: DEFAULT_TARGET_MILLIS
+
+    fun targetAfterRebuffer(currentTargetMillis: Long): Long =
+        (targetFor(currentTargetMillis) + REBUFFER_STEP_MILLIS)
+            .coerceAtMost(MAX_TARGET_MILLIS)
+}

--- a/app/src/main/java/app/opentv/player/PlayerController.kt
+++ b/app/src/main/java/app/opentv/player/PlayerController.kt
@@ -18,6 +18,7 @@ import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
+import androidx.media3.exoplayer.DefaultLivePlaybackSpeedControl
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
@@ -104,6 +105,8 @@ class PlayerController(
         /** Live streams are never resumed; VOD is. */
         val startPositionMillis: Long = 0L,
         val isLive: Boolean = true,
+        /** Stable database identity used only to remember this channel's learned live target. */
+        val channelId: Long? = null,
     )
 
     private val _state = MutableStateFlow<State>(State.Idle)
@@ -116,6 +119,21 @@ class PlayerController(
     private var switchJob: Job? = null
     private var current: Request? = null
     private var consecutiveFailures = 0
+    private var currentLiveTargetMillis = AdaptiveLivePolicy.DEFAULT_TARGET_MILLIS
+    private var currentReachedReady = false
+
+    private val liveTargetPreferences = context.getSharedPreferences(
+        LIVE_TARGET_PREFERENCES,
+        Context.MODE_PRIVATE,
+    )
+
+    /**
+     * Media3 already moves its target after a rebuffer. Five seconds reacts quickly enough for
+     * IPTV segment-publication gaps; the stock 500 ms step can require many visible stalls.
+     */
+    private val livePlaybackSpeedControl = DefaultLivePlaybackSpeedControl.Builder()
+        .setTargetLiveOffsetIncrementOnRebufferMs(AdaptiveLivePolicy.REBUFFER_STEP_MILLIS)
+        .build()
 
     /**
      * Held so the User-Agent can be swapped per source before each tune.
@@ -187,6 +205,7 @@ class PlayerController(
                 .setLoadErrorHandlingPolicy(loadErrorPolicy),
         )
         .setTrackSelector(trackSelector)
+        .setLivePlaybackSpeedControl(livePlaybackSpeedControl)
         .setLoadControl(
             DefaultLoadControl.Builder()
                 .setBufferDurationsMs(
@@ -221,10 +240,28 @@ class PlayerController(
 
                 override fun onPlaybackStateChanged(playbackState: Int) {
                     val title = current?.title.orEmpty()
+                    if (
+                        playbackState == Player.STATE_BUFFERING &&
+                        currentReachedReady &&
+                        !preview &&
+                        !dvr &&
+                        current?.let(::usesAdaptiveHlsPolicy) == true
+                    ) {
+                        val learnedTarget = AdaptiveLivePolicy.targetAfterRebuffer(currentLiveTargetMillis)
+                        if (learnedTarget != currentLiveTargetMillis) {
+                            currentLiveTargetMillis = learnedTarget
+                            current?.channelId?.let { channelId ->
+                                liveTargetPreferences.edit()
+                                    .putLong(liveTargetKey(channelId), learnedTarget)
+                                    .apply()
+                            }
+                        }
+                    }
                     _state.value = when (playbackState) {
                         Player.STATE_BUFFERING -> State.Buffering(title)
                         Player.STATE_READY -> {
                             consecutiveFailures = 0
+                            currentReachedReady = true
                             State.Playing(title)
                         }
                         Player.STATE_IDLE -> _state.value
@@ -269,17 +306,24 @@ class PlayerController(
             if (debounce) delay(switchDebounceMillis)
 
             consecutiveFailures = 0
+            currentReachedReady = false
             httpFactory.setDefaultRequestProperties(mapOf("User-Agent" to request.userAgent))
             _state.value = State.Buffering(request.title)
+
+            val adaptiveHls = usesAdaptiveHlsPolicy(request)
+            val savedLiveTarget = request.channelId?.takeIf { adaptiveHls }?.let { channelId ->
+                val key = liveTargetKey(channelId)
+                if (liveTargetPreferences.contains(key)) liveTargetPreferences.getLong(key, 0L) else null
+            }
+            currentLiveTargetMillis = AdaptiveLivePolicy.targetFor(savedLiveTarget)
 
             val mediaItem = MediaItem.Builder()
                 .setUri(request.url)
                 .apply {
-                    // Only meaningful for live streams; setting it on VOD skews seeking.
-                    if (request.isLive) {
+                    if (adaptiveHls) {
                         setLiveConfiguration(
                             MediaItem.LiveConfiguration.Builder()
-                                .setTargetOffsetMs(LIVE_TARGET_OFFSET_MILLIS)
+                                .setTargetOffsetMs(currentLiveTargetMillis)
                                 .build(),
                         )
                     }
@@ -385,6 +429,7 @@ class PlayerController(
         const val MAX_LOAD_RETRIES = 5
         const val MAX_AUTO_RESTARTS = 3
         const val AUTO_RESTART_DELAY_MILLIS = 1_500L
+        const val LIVE_TARGET_PREFERENCES = "adaptive_live_targets_v1"
 
         /**
          * Larger than ExoPlayer's defaults. IPTV sources are much twitchier than a CDN, and a
@@ -421,6 +466,10 @@ class PlayerController(
         const val PREVIEW_BUFFER_AFTER_REBUFFER_MILLIS = 1_500
         const val PREVIEW_SWITCH_DEBOUNCE_MILLIS = 700L
 
-        const val LIVE_TARGET_OFFSET_MILLIS = 10_000L
     }
+
+    private fun liveTargetKey(channelId: Long): String = "channel_$channelId"
+
+    private fun usesAdaptiveHlsPolicy(request: Request): Boolean =
+        AdaptiveLivePolicy.appliesTo(request.isLive, request.url)
 }

--- a/app/src/main/java/app/opentv/ui/channels/HomeScreen.kt
+++ b/app/src/main/java/app/opentv/ui/channels/HomeScreen.kt
@@ -286,6 +286,7 @@ fun HomeScreen(
                 title = channel.shownName,
                 userAgent = source?.userAgent ?: "OpenTV/0.1 (Android)",
                 isLive = true,
+                channelId = channel.id,
             ),
             debounce = true,
         )

--- a/app/src/main/java/app/opentv/ui/player/PlayerScreen.kt
+++ b/app/src/main/java/app/opentv/ui/player/PlayerScreen.kt
@@ -230,6 +230,7 @@ fun PlayerScreen(
                     title = channel.shownName,
                     userAgent = source?.userAgent ?: "OpenTV/0.1 (Android)",
                     isLive = true,
+                    channelId = channel.id,
                 ),
                 debounce = false,
             )

--- a/app/src/test/java/app/opentv/AdaptiveLivePolicyTest.kt
+++ b/app/src/test/java/app/opentv/AdaptiveLivePolicyTest.kt
@@ -1,0 +1,43 @@
+/*
+ * This file is part of OpenTV.
+ * Copyright (C) 2026 The OpenTV Contributors
+ * Licensed under the GNU General Public License v3.0 or later.
+ */
+package app.opentv
+
+import app.opentv.player.AdaptiveLivePolicy
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class AdaptiveLivePolicyTest {
+
+    @Test
+    fun `policy applies only to live HLS urls`() {
+        assertThat(AdaptiveLivePolicy.appliesTo(true, "https://example.com/live/1.m3u8?token=x"))
+            .isTrue()
+        assertThat(AdaptiveLivePolicy.appliesTo(true, "https://example.com/live/1.M3U8"))
+            .isTrue()
+        assertThat(AdaptiveLivePolicy.appliesTo(true, "https://example.com/live/1.ts"))
+            .isFalse()
+        assertThat(AdaptiveLivePolicy.appliesTo(false, "https://example.com/vod/1.m3u8"))
+            .isFalse()
+    }
+
+    @Test
+    fun `new channels start at the safety target`() {
+        assertThat(AdaptiveLivePolicy.targetFor(null)).isEqualTo(30_000L)
+    }
+
+    @Test
+    fun `a rebuffer moves only that channel one safety step farther back`() {
+        assertThat(AdaptiveLivePolicy.targetAfterRebuffer(30_000L)).isEqualTo(35_000L)
+        assertThat(AdaptiveLivePolicy.targetAfterRebuffer(35_000L)).isEqualTo(40_000L)
+    }
+
+    @Test
+    fun `broken or stale saved values are bounded`() {
+        assertThat(AdaptiveLivePolicy.targetFor(5_000L)).isEqualTo(30_000L)
+        assertThat(AdaptiveLivePolicy.targetFor(90_000L)).isEqualTo(60_000L)
+        assertThat(AdaptiveLivePolicy.targetAfterRebuffer(60_000L)).isEqualTo(60_000L)
+    }
+}


### PR DESCRIPTION
## Summary

- replace the single 10-second live offset with an HLS-only 30-second safety target
- move 5 seconds farther from live after a post-startup rebuffer and remember that target per channel
- clamp learned targets to 30-60 seconds and leave MPEG-TS, VOD, recordings, preview learning, and DVR learning unchanged
- add unit coverage for transport scoping, query strings/case, learning steps, and bounds

## Why

On an NVIDIA Shield running Android 11 with an Xtream HLS source, the fixed 10-second target repeatedly exhausted the available media buffer even while hardware H.264 decoding and frame delivery remained healthy.

A controlled same-channel sample at 10 seconds had four post-startup rebuffers in 113.7 seconds, reached 289 ms buffered, and spent 19 one-second samples below 3 seconds. A 30-second control on the same channel had no post-startup rebuffer or sub-3-second sample in 113.1 seconds.

Trusting each manifest without a safety floor was also tested and rejected: one channel derived 33 seconds and remained stable, while another advertised about 10.1 seconds and rebuffered after roughly ten seconds. With the final 30-second floor, three live-channel samples completed without a post-startup rebuffer, sub-3-second sample, or dropped decoder frame:

| Channel sample | Window | Minimum buffer | Median buffer |
|---|---:|---:|---:|
| ABC East | 113.1 s | 8,135 ms | 16,801 ms |
| A&E | 130.8 s | 12,188 ms | 25,541 ms |
| ABC News | 99.9 s | 10,434 ms | 37,414 ms |

The adaptive step preserves smoothness when a particular feed needs more margin without forcing every channel to the 60-second ceiling. Only the learned timing value is persisted under the channel's database ID; no stream URL, title, headers, playlist content, or provider credentials are stored or logged.

## Validation

- `./gradlew test assembleDebug`
- `./gradlew :app:testReleaseUnitTest :app:assembleRelease`
- release lint, R8, resource shrinking, and APK packaging
- live-device A/B testing described above