### PR TITLE
Keep the current channel playing in the guide preview

### DIFF
--- a/app/src/main/java/app/opentv/core/AppSettings.kt
+++ b/app/src/main/java/app/opentv/core/AppSettings.kt
@@ -44,6 +44,12 @@ class AppSettings private constructor(context: Context) {
     private val _channelLayout = MutableStateFlow(readChannelLayout())
     val channelLayout: StateFlow<ChannelLayout> = _channelLayout.asStateFlow()
 
+    /** Which channel the guide's video pane plays while focus moves through the guide. */
+    enum class GuidePreviewMode { CURRENT_CHANNEL, HIGHLIGHTED_CHANNEL }
+
+    private val _guidePreviewMode = MutableStateFlow(readGuidePreviewMode())
+    val guidePreviewMode: StateFlow<GuidePreviewMode> = _guidePreviewMode.asStateFlow()
+
     /** Whether embedded subtitles/closed captions are shown when a stream carries them. */
     private val _subtitlesEnabled = MutableStateFlow(prefs.getBoolean(KEY_SUBTITLES, true))
     val subtitlesEnabled: StateFlow<Boolean> = _subtitlesEnabled.asStateFlow()
@@ -122,6 +128,11 @@ class AppSettings private constructor(context: Context) {
     fun setChannelLayout(layout: ChannelLayout) {
         prefs.edit().putString(KEY_CHANNEL_LAYOUT, layout.name).apply()
         _channelLayout.value = layout
+    }
+
+    fun setGuidePreviewMode(mode: GuidePreviewMode) {
+        prefs.edit().putString(KEY_PREVIEW_MODE, mode.name).apply()
+        _guidePreviewMode.value = mode
     }
 
     fun setSubtitlesEnabled(enabled: Boolean) {
@@ -268,6 +279,10 @@ class AppSettings private constructor(context: Context) {
     private fun readChannelLayout(): ChannelLayout =
         runCatching { ChannelLayout.valueOf(prefs.getString(KEY_CHANNEL_LAYOUT, null) ?: "") }
             .getOrDefault(ChannelLayout.GRID)
+
+    private fun readGuidePreviewMode(): GuidePreviewMode =
+        runCatching { GuidePreviewMode.valueOf(prefs.getString(KEY_PREVIEW_MODE, null) ?: "") }
+            .getOrDefault(GuidePreviewMode.CURRENT_CHANNEL)
 
     // ---- Recording ---------------------------------------------------------------------------
 
@@ -426,6 +441,7 @@ class AppSettings private constructor(context: Context) {
         private const val KEY_SUBTITLES = "subtitles_enabled"
         private const val KEY_PREVIEW_VIDEO = "guide_preview_video"
         private const val KEY_PREVIEW_SOUND = "guide_preview_sound"
+        private const val KEY_PREVIEW_MODE = "guide_preview_mode"
         private const val KEY_PIN_HASH = "parental_pin_hash"
         private const val KEY_HIDDEN_CATS = "hidden_categories"
         private const val KEY_ACTIVE_PROFILE = "active_profile_id"

--- a/app/src/main/java/app/opentv/ui/channels/GuidePreviewPolicy.kt
+++ b/app/src/main/java/app/opentv/ui/channels/GuidePreviewPolicy.kt
@@ -1,0 +1,32 @@
+/*
+ * This file is part of OpenTV.
+ * Copyright (C) 2026 The OpenTV Contributors
+ * Licensed under the GNU General Public License v3.0 or later.
+ */
+package app.opentv.ui.channels
+
+import app.opentv.core.AppSettings
+
+/** Pure selection policy kept outside Compose so the guide-preview contract is unit-testable. */
+internal object GuidePreviewPolicy {
+    fun channelId(
+        mode: AppSettings.GuidePreviewMode,
+        currentChannelId: Long,
+        highlightedChannelId: Long?,
+    ): Long? = when (mode) {
+        AppSettings.GuidePreviewMode.CURRENT_CHANNEL ->
+            currentChannelId.takeIf { it > 0L } ?: highlightedChannelId
+        AppSettings.GuidePreviewMode.HIGHLIGHTED_CHANNEL -> highlightedChannelId
+    }
+
+    /** The Watch control belongs to the video card, so it must open the video actually shown. */
+    fun watchChannelId(
+        previewVisible: Boolean,
+        previewChannelId: Long?,
+        highlightedChannelId: Long?,
+    ): Long? = if (previewVisible) {
+        previewChannelId ?: highlightedChannelId
+    } else {
+        highlightedChannelId
+    }
+}

--- a/app/src/main/java/app/opentv/ui/channels/HomeScreen.kt
+++ b/app/src/main/java/app/opentv/ui/channels/HomeScreen.kt
@@ -121,6 +121,7 @@ fun HomeScreen(
     val graph = remember { ServiceLocator.get(context) }
     val settings = remember { graph.settings }
     val previewEnabled by settings.guidePreviewVideo.collectAsState()
+    val previewMode by settings.guidePreviewMode.collectAsState()
     val channelLayout by settings.channelLayout.collectAsState()
 
     val categories by viewModel.visibleCategoryGroups.collectAsState()
@@ -136,12 +137,11 @@ fun HomeScreen(
     // empty. Drives the choice between the loading spinner and a recoverable error below.
     val channelsPresent by viewModel.channelsPresent.collectAsState()
 
-    // Two separate ideas, on purpose:
-    //  - highlightedRow: where the d-pad is in the grid. Moves freely with up/down.
-    //  - selectedRow: what the preview pane plays. Only changes when you press OK, so scrolling
-    //    the list is calm and silent instead of re-tuning a stream on every keypress.
+    // The highlight is where the d-pad is in the grid. The preview stream is selected separately:
+    // by default it remains on the last full-screen channel, with focus-following available as a
+    // setting for viewers who prefer the old browse-to-preview behaviour.
     var highlightedRow by remember { mutableStateOf<ChannelsViewModel.Row?>(null) }
-    var selectedRow by remember { mutableStateOf<ChannelsViewModel.Row?>(null) }
+    var currentChannelId by remember { mutableLongStateOf(settings.lastChannelId) }
     val previewSound by settings.guidePreviewSound.collectAsState()
     var nowMillis by remember { mutableLongStateOf(System.currentTimeMillis()) }
 
@@ -195,11 +195,9 @@ fun HomeScreen(
         }
     }
 
-    // Keep both valid as the list changes (e.g. switching category): stay on the same channel if
-    // it's still present, otherwise fall back to the top of the new list.
+    // Keep the browsing highlight valid as the list changes (for example, switching category).
     LaunchedEffect(rows) {
         highlightedRow = rows.firstOrNull { it.key == highlightedRow?.key } ?: rows.firstOrNull()
-        selectedRow = rows.firstOrNull { it.key == selectedRow?.key } ?: rows.firstOrNull()
     }
 
     // ---- Live preview player -----------------------------------------------------------------
@@ -238,7 +236,12 @@ fun HomeScreen(
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             when (event) {
-                Lifecycle.Event.ON_RESUME -> screenResumed = true
+                Lifecycle.Event.ON_RESUME -> {
+                    // PlayerScreen writes this before playback begins. Re-read it every time the
+                    // guide returns so Back immediately restores that same channel in the preview.
+                    currentChannelId = settings.lastChannelId
+                    screenResumed = true
+                }
                 Lifecycle.Event.ON_PAUSE -> {
                     screenResumed = false
                     previewController.stop()
@@ -262,23 +265,47 @@ fun HomeScreen(
         onDispose { window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON) }
     }
 
-    // Preview audio follows the setting; muted by default so browsing stays quiet.
+    // Preview audio follows the existing sound setting.
     LaunchedEffect(previewSound) {
         previewController.player.volume = if (previewSound) 1f else 0f
     }
 
-    // Tune the preview to the highlighted channel, so it follows the d-pad as you browse — the
-    // standard TV-guide behaviour. Debounced, so holding a direction doesn't re-tune every step.
+    // By default the preview returns to the channel that was playing full-screen and stays there
+    // while focus moves through the guide. The alternate setting follows the highlighted channel;
+    // only that mode is debounced so holding a direction doesn't re-tune every step.
     // While a recording is running the preview is silenced entirely: on a single-connection line a
     // muted preview is still a second stream, which fights the recording and risks a provider ban.
     val recordingActive = activeRecordings.isNotEmpty()
-    LaunchedEffect(highlightedRow?.key, previewEnabled, screenResumed, recordingActive) {
-        val row = highlightedRow
-        if (!previewEnabled || !screenResumed || recordingActive || row == null) {
+    val highlightedChannel = highlightedRow?.primary
+    val previewChannelId = GuidePreviewPolicy.channelId(
+        mode = previewMode,
+        currentChannelId = currentChannelId,
+        highlightedChannelId = highlightedChannel?.id,
+    )
+    val previewVisible = previewEnabled && !recordingActive
+    val watchChannelId = GuidePreviewPolicy.watchChannelId(
+        previewVisible = previewVisible,
+        previewChannelId = previewChannelId,
+        highlightedChannelId = highlightedChannel?.id,
+    )
+    LaunchedEffect(
+        previewChannelId,
+        previewEnabled,
+        screenResumed,
+        recordingActive,
+    ) {
+        if (!previewEnabled || !screenResumed || recordingActive || previewChannelId == null) {
             previewController.stop()
             return@LaunchedEffect
         }
-        val channel = row.primary
+        val channel = if (previewChannelId == highlightedChannel?.id) {
+            highlightedChannel
+        } else {
+            graph.catalogRepository.channel(previewChannelId)
+        } ?: highlightedChannel ?: run {
+            previewController.stop()
+            return@LaunchedEffect
+        }
         val source = graph.sourceRepository.byId(channel.sourceId)
         previewController.play(
             PlayerController.Request(
@@ -287,7 +314,7 @@ fun HomeScreen(
                 userAgent = source?.userAgent ?: "OpenTV/0.1 (Android)",
                 isLive = true,
             ),
-            debounce = true,
+            debounce = previewMode == AppSettings.GuidePreviewMode.HIGHLIGHTED_CHANNEL,
         )
     }
 
@@ -420,10 +447,20 @@ fun HomeScreen(
                 GuidePreview(
                     row = highlightedRow,
                     nowMillis = nowMillis,
-                    onWatch = { highlightedRow?.let { goFullscreen(it.primary) } },
+                    onWatch = {
+                        watchChannelId?.let { id ->
+                            if (id == highlightedChannel?.id) {
+                                highlightedChannel?.let(::goFullscreen)
+                            } else {
+                                recordScope.launch {
+                                    graph.catalogRepository.channel(id)?.let(::goFullscreen)
+                                }
+                            }
+                        }
+                    },
                     onRefresh = onRefresh,
                     onAddSource = onAddSource,
-                    previewPlayer = if (previewEnabled && !recordingActive) previewController.player else null,
+                    previewPlayer = if (previewVisible) previewController.player else null,
                     isRecording = highlightedRow?.primary?.id?.let { id ->
                         activeRecordings.any { it.channelId == id }
                     } == true,

--- a/app/src/main/java/app/opentv/ui/settings/AppSettingsScreen.kt
+++ b/app/src/main/java/app/opentv/ui/settings/AppSettingsScreen.kt
@@ -60,6 +60,7 @@ fun AppSettingsScreen(onBack: () -> Unit) {
     val settings = remember { AppSettings.get(context) }
     val themeMode by settings.themeMode.collectAsState()
     val channelLayout by settings.channelLayout.collectAsState()
+    val previewMode by settings.guidePreviewMode.collectAsState()
     val previewVideo by settings.guidePreviewVideo.collectAsState()
     val previewSound by settings.guidePreviewSound.collectAsState()
     val captions by settings.subtitlesEnabled.collectAsState()
@@ -175,6 +176,24 @@ fun AppSettingsScreen(onBack: () -> Unit) {
                 stringResource(R.string.settings_channel_layout_list),
                 channelLayout == AppSettings.ChannelLayout.LIST,
             ) { settings.setChannelLayout(AppSettings.ChannelLayout.LIST) }
+            Spacer(Modifier.height(8.dp))
+            Text(
+                stringResource(R.string.settings_preview_channel_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            ThemeOption(
+                stringResource(R.string.settings_preview_channel_current),
+                previewMode == AppSettings.GuidePreviewMode.CURRENT_CHANNEL,
+            ) { settings.setGuidePreviewMode(AppSettings.GuidePreviewMode.CURRENT_CHANNEL) }
+            ThemeOption(
+                stringResource(R.string.settings_preview_channel_highlighted),
+                previewMode == AppSettings.GuidePreviewMode.HIGHLIGHTED_CHANNEL,
+            ) { settings.setGuidePreviewMode(AppSettings.GuidePreviewMode.HIGHLIGHTED_CHANNEL) }
+            Text(
+                stringResource(R.string.settings_preview_channel_note),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
             Spacer(Modifier.height(8.dp))
             ToggleRow(
                 title = stringResource(R.string.settings_live_preview_title),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -184,8 +184,12 @@
     <string name="settings_channel_layout_title">Channel layout</string>
     <string name="settings_channel_layout_grid">Guide grid (with timeline)</string>
     <string name="settings_channel_layout_list">Simple list</string>
+    <string name="settings_preview_channel_title" translatable="false">Guide preview channel</string>
+    <string name="settings_preview_channel_current" translatable="false">Keep playing the current channel</string>
+    <string name="settings_preview_channel_highlighted" translatable="false">Follow the highlighted channel</string>
+    <string name="settings_preview_channel_note" translatable="false">Choose whether browsing leaves the channel you were watching in the preview pane or retunes the preview as you move through the guide.</string>
     <string name="settings_live_preview_title">Live preview in the guide</string>
-    <string name="settings_live_preview_subtitle">Play the selected channel in the preview pane. Turn this off if the guide stutters on an older box.</string>
+    <string name="settings_live_preview_subtitle">Play live TV in the preview pane. Turn this off if the guide stutters on an older box.</string>
     <string name="settings_preview_sound_title">Preview sound</string>
     <string name="settings_preview_sound_subtitle">Play the preview channel\'s audio too, not just the picture.</string>
     <string name="settings_section_playback">Playback</string>

--- a/app/src/test/java/app/opentv/GuidePreviewPolicyTest.kt
+++ b/app/src/test/java/app/opentv/GuidePreviewPolicyTest.kt
@@ -1,0 +1,97 @@
+/*
+ * This file is part of OpenTV.
+ * Copyright (C) 2026 The OpenTV Contributors
+ * Licensed under the GNU General Public License v3.0 or later.
+ */
+package app.opentv
+
+import app.opentv.core.AppSettings
+import app.opentv.ui.channels.GuidePreviewPolicy
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class GuidePreviewPolicyTest {
+    @Test
+    fun currentModeKeepsThePlayingChannel() {
+        assertEquals(
+            42L,
+            GuidePreviewPolicy.channelId(
+                AppSettings.GuidePreviewMode.CURRENT_CHANNEL,
+                currentChannelId = 42L,
+                highlightedChannelId = 99L,
+            ),
+        )
+    }
+
+    @Test
+    fun currentModeFallsBackToHighlightBeforeFirstPlayback() {
+        assertEquals(
+            99L,
+            GuidePreviewPolicy.channelId(
+                AppSettings.GuidePreviewMode.CURRENT_CHANNEL,
+                currentChannelId = 0L,
+                highlightedChannelId = 99L,
+            ),
+        )
+    }
+
+    @Test
+    fun highlightedModeFollowsBrowsing() {
+        assertEquals(
+            99L,
+            GuidePreviewPolicy.channelId(
+                AppSettings.GuidePreviewMode.HIGHLIGHTED_CHANNEL,
+                currentChannelId = 42L,
+                highlightedChannelId = 99L,
+            ),
+        )
+    }
+
+    @Test
+    fun noChannelIsChosenBeforePlaybackOrGuideData() {
+        assertNull(
+            GuidePreviewPolicy.channelId(
+                AppSettings.GuidePreviewMode.CURRENT_CHANNEL,
+                currentChannelId = 0L,
+                highlightedChannelId = null,
+            ),
+        )
+    }
+
+    @Test
+    fun watchOpensTheChannelShownInThePreview() {
+        assertEquals(
+            42L,
+            GuidePreviewPolicy.watchChannelId(
+                previewVisible = true,
+                previewChannelId = 42L,
+                highlightedChannelId = 99L,
+            ),
+        )
+    }
+
+    @Test
+    fun watchUsesHighlightWhenPreviewIsHidden() {
+        assertEquals(
+            99L,
+            GuidePreviewPolicy.watchChannelId(
+                previewVisible = false,
+                previewChannelId = 42L,
+                highlightedChannelId = 99L,
+            ),
+        )
+    }
+
+    @Test
+    fun watchFallsBackToHighlightWhilePreviewTargetIsUnavailable() {
+        assertEquals(
+            99L,
+            GuidePreviewPolicy.watchChannelId(
+                previewVisible = true,
+                previewChannelId = null,
+                highlightedChannelId = 99L,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Why

Pressing Back from a live channel currently returns to a guide preview that follows the browsing highlight. Moving focus therefore retunes the stream instead of letting viewers keep watching the channel they just left.

This adds an explicit guide preference so the preview can keep the last full-screen channel playing while focus moves independently. The existing follow-the-highlight behavior remains available. The Watch action also follows the video actually visible in the preview; otherwise a preview showing one channel could open a different highlighted channel.

## What changed

- persist a `GuidePreviewMode` setting, defaulting to the current channel
- re-read `lastChannelId` when the guide resumes after full-screen playback
- keep highlight-following as an alternate setting and debounce only that mode
- make Watch target the visible preview channel, with safe highlighted-channel fallbacks
- add a pure selection policy with unit coverage for both modes and Watch behavior

This PR contains no device-specific button mapping, PiP automation, provider data, or custom version metadata.

## Validation

- `./gradlew test`
- `./gradlew testDebugUnitTest testReleaseUnitTest lintVitalRelease assembleRelease`
- NVIDIA Shield / Android 11 device test: MLB Atlanta Braves remained in the preview while A&E was highlighted; Watch opened MLB Atlanta Braves full-screen, and Back restored the same preview with A&E still highlighted.