### PR TITLE
Persist final status when a recording is canceled

### DIFF
--- a/app/src/main/java/app/opentv/recording/RecordingFinalizer.kt
+++ b/app/src/main/java/app/opentv/recording/RecordingFinalizer.kt
@@ -1,0 +1,16 @@
+/*
+ * This file is part of OpenTV.
+ * Copyright (C) 2026 The OpenTV Contributors
+ * Licensed under the GNU General Public License v3.0 or later.
+ */
+package app.opentv.recording
+
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+
+/** Runs terminal recording cleanup even when the capture job was canceled by a user stop. */
+internal object RecordingFinalizer {
+    suspend fun run(block: suspend () -> Unit) {
+        withContext(NonCancellable) { block() }
+    }
+}

--- a/app/src/main/java/app/opentv/recording/RecordingService.kt
+++ b/app/src/main/java/app/opentv/recording/RecordingService.kt
@@ -168,20 +168,26 @@ class RecordingService : Service() {
                 Log.w(TAG, "Recording $id failed", t)
             }
         } finally {
-            // The file is now at its final size — anyone watching it should see the true end.
-            RecordingLiveState.markInactive(id)
-            runCatching { sink?.close() }
-            val ok = total > 0 && error == null
-            runCatching {
-                repo.markFinished(
-                    id = id,
-                    ok = ok,
-                    atMillis = System.currentTimeMillis(),
-                    bytes = total,
-                    error = if (ok) null else (error ?: getString(R.string.rec_error_nothing)),
-                )
+            // A user stop cancels this coroutine. Cleanup must outlive that cancellation or Room's
+            // suspended status write is skipped, leaving a phantom RECORDING row after capture ends.
+            RecordingFinalizer.run {
+                // The file is now at its final size — anyone watching it should see the true end.
+                RecordingLiveState.markInactive(id)
+                runCatching { sink?.close() }
+                val ok = total > 0 && error == null
+                runCatching {
+                    repo.markFinished(
+                        id = id,
+                        ok = ok,
+                        atMillis = System.currentTimeMillis(),
+                        bytes = total,
+                        error = if (ok) null else (error ?: getString(R.string.rec_error_nothing)),
+                    )
+                }.onFailure { throwable ->
+                    Log.e(TAG, "Recording $id could not persist final status", throwable)
+                }
+                finish(id)
             }
-            finish(id)
         }
     }
 

--- a/app/src/test/java/app/opentv/RecordingFinalizerTest.kt
+++ b/app/src/test/java/app/opentv/RecordingFinalizerTest.kt
@@ -1,0 +1,40 @@
+/*
+ * This file is part of OpenTV.
+ * Copyright (C) 2026 The OpenTV Contributors
+ * Licensed under the GNU General Public License v3.0 or later.
+ */
+package app.opentv
+
+import app.opentv.recording.RecordingFinalizer
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RecordingFinalizerTest {
+    @Test
+    fun cleanupCanSuspendAndCompleteAfterCaptureCancellation() = runTest {
+        var cleanupStarted = false
+        var cleanupFinished = false
+        val capture = launch(start = CoroutineStart.UNDISPATCHED) {
+            try {
+                awaitCancellation()
+            } finally {
+                RecordingFinalizer.run {
+                    cleanupStarted = true
+                    yield()
+                    cleanupFinished = true
+                }
+            }
+        }
+
+        capture.cancelAndJoin()
+
+        assertTrue(cleanupStarted)
+        assertTrue(cleanupFinished)
+    }
+}


### PR DESCRIPTION
## Why

Stopping a recording cancels its capture coroutine. The coroutine then enters `finally`, but its Room `markFinished` call is suspendable and still inherits the canceled job. That write can be skipped, leaving the row stuck as `RECORDING` after the file capture and foreground service have ended.

The stale row keeps the guide showing Stop instead of Record and can suppress the guide preview because OpenTV still believes a recording is active.

## What changed

- run terminal recording cleanup in a `NonCancellable` context
- close the sink, persist the final status, and retire the service capture before leaving cleanup
- log a database-finalization failure instead of silently swallowing it
- add a coroutine regression test that cancels the parent job, suspends inside cleanup, and verifies cleanup still completes

## Validation

- `./gradlew test`
- `./gradlew test lintVitalRelease assembleRelease`
- NVIDIA Shield / Android 11 device test: canceling a recording retired `RecordingService`, changed the guide control from Stop back to Record, and immediately restored the live guide preview. A pre-fix stale row was reconciled as interrupted and no longer remained active.

This PR contains no provider data, device-specific automation, custom version metadata, or unrelated guide/PiP changes.