### PR TITLE
Make TV guide navigation direct and preserve live playback

### DIFF
--- a/app/src/main/java/app/opentv/core/AppSettings.kt
+++ b/app/src/main/java/app/opentv/core/AppSettings.kt
@@ -44,6 +44,12 @@ class AppSettings private constructor(context: Context) {
     private val _channelLayout = MutableStateFlow(readChannelLayout())
     val channelLayout: StateFlow<ChannelLayout> = _channelLayout.asStateFlow()
 
+    /** Which channel the guide's video pane plays while focus moves through the guide. */
+    enum class GuidePreviewMode { CURRENT_CHANNEL, HIGHLIGHTED_CHANNEL }
+
+    private val _guidePreviewMode = MutableStateFlow(readGuidePreviewMode())
+    val guidePreviewMode: StateFlow<GuidePreviewMode> = _guidePreviewMode.asStateFlow()
+
     /** Whether embedded subtitles/closed captions are shown when a stream carries them. */
     private val _subtitlesEnabled = MutableStateFlow(prefs.getBoolean(KEY_SUBTITLES, true))
     val subtitlesEnabled: StateFlow<Boolean> = _subtitlesEnabled.asStateFlow()
@@ -122,6 +128,11 @@ class AppSettings private constructor(context: Context) {
     fun setChannelLayout(layout: ChannelLayout) {
         prefs.edit().putString(KEY_CHANNEL_LAYOUT, layout.name).apply()
         _channelLayout.value = layout
+    }
+
+    fun setGuidePreviewMode(mode: GuidePreviewMode) {
+        prefs.edit().putString(KEY_PREVIEW_MODE, mode.name).apply()
+        _guidePreviewMode.value = mode
     }
 
     fun setSubtitlesEnabled(enabled: Boolean) {
@@ -268,6 +279,10 @@ class AppSettings private constructor(context: Context) {
     private fun readChannelLayout(): ChannelLayout =
         runCatching { ChannelLayout.valueOf(prefs.getString(KEY_CHANNEL_LAYOUT, null) ?: "") }
             .getOrDefault(ChannelLayout.GRID)
+
+    private fun readGuidePreviewMode(): GuidePreviewMode =
+        runCatching { GuidePreviewMode.valueOf(prefs.getString(KEY_PREVIEW_MODE, null) ?: "") }
+            .getOrDefault(GuidePreviewMode.CURRENT_CHANNEL)
 
     // ---- Recording ---------------------------------------------------------------------------
 
@@ -426,6 +441,7 @@ class AppSettings private constructor(context: Context) {
         private const val KEY_SUBTITLES = "subtitles_enabled"
         private const val KEY_PREVIEW_VIDEO = "guide_preview_video"
         private const val KEY_PREVIEW_SOUND = "guide_preview_sound"
+        private const val KEY_PREVIEW_MODE = "guide_preview_mode"
         private const val KEY_PIN_HASH = "parental_pin_hash"
         private const val KEY_HIDDEN_CATS = "hidden_categories"
         private const val KEY_ACTIVE_PROFILE = "active_profile_id"

--- a/app/src/main/java/app/opentv/core/ServiceLocator.kt
+++ b/app/src/main/java/app/opentv/core/ServiceLocator.kt
@@ -16,6 +16,7 @@ import app.opentv.data.repo.RecordingRepository
 import app.opentv.data.repo.ReminderRepository
 import app.opentv.data.repo.SourceRepository
 import app.opentv.recording.RecordingEngine
+import app.opentv.player.LivePlaybackSession
 import java.util.concurrent.TimeUnit
 import okhttp3.OkHttpClient
 
@@ -72,6 +73,11 @@ object ServiceLocator {
                 .followSslRedirects(true)
                 .retryOnConnectionFailure(true)
                 .build()
+        }
+
+        /** One live player shared by the guide preview and the full-screen live destination. */
+        val livePlaybackSession: LivePlaybackSession by lazy {
+            LivePlaybackSession(appContext, streamingHttpClient, settings)
         }
 
         val xtreamApi: XtreamApi by lazy { XtreamApi(httpClient) }

--- a/app/src/main/java/app/opentv/player/LivePlaybackSession.kt
+++ b/app/src/main/java/app/opentv/player/LivePlaybackSession.kt
@@ -1,0 +1,108 @@
+/*
+ * This file is part of OpenTV.
+ * Copyright (C) 2026 The OpenTV Contributors
+ * Licensed under the GNU General Public License v3.0 or later.
+ */
+package app.opentv.player
+
+import android.content.Context
+import app.opentv.core.AppSettings
+import java.util.EnumSet
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import okhttp3.OkHttpClient
+
+/**
+ * Owns live playback across the guide and full-screen destinations.
+ *
+ * The guide and player used to own separate ExoPlayer instances. Navigating between them stopped
+ * one stream and opened the same URL again in the other, producing a visible reload. This session
+ * keeps one controller alive and lets each destination attach its own PlayerView to the existing
+ * player. An explicit, short handoff window preserves playback while Navigation Compose swaps the
+ * destinations; leaving live TV for any unrelated screen still stops immediately.
+ */
+class LivePlaybackSession(
+    context: Context,
+    httpClient: OkHttpClient,
+    settings: AppSettings,
+) {
+    enum class Surface { GUIDE, PLAYER }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val attachedSurfaces = EnumSet.noneOf(Surface::class.java)
+    private var pendingHandoff: Surface? = null
+    private var handoffExpiryJob: Job? = null
+
+    val controller = PlayerController(
+        context = context,
+        scope = scope,
+        httpClient = httpClient,
+        subtitlesEnabled = settings.subtitlesEnabled.value,
+        dvr = settings.livePauseEnabled.value,
+    )
+
+    fun attach(surface: Surface) {
+        attachedSurfaces += surface
+        if (pendingHandoff == surface) {
+            pendingHandoff = null
+            handoffExpiryJob?.cancel()
+            handoffExpiryJob = null
+        }
+    }
+
+    fun detach(surface: Surface) {
+        attachedSurfaces -= surface
+        if (attachedSurfaces.isNotEmpty()) return
+
+        // If navigation is between the two live surfaces, the destination gets a brief chance to
+        // attach. All other departures stop synchronously so audio cannot leak into another tab.
+        if (pendingHandoff == null) stop()
+    }
+
+    fun prepareHandoff(target: Surface) {
+        pendingHandoff = target
+        handoffExpiryJob?.cancel()
+        handoffExpiryJob = scope.launch {
+            delay(HANDOFF_TIMEOUT_MILLIS)
+            if (pendingHandoff == target) {
+                pendingHandoff = null
+                handoffExpiryJob = null
+                if (attachedSurfaces.isEmpty()) stop()
+            }
+        }
+    }
+
+    /** Returns true when the current media item and buffer were reused without a new prepare. */
+    fun play(
+        request: PlayerController.Request,
+        debounce: Boolean,
+        debounceMillis: Long? = null,
+    ): Boolean {
+        if (controller.canReuse(request)) return true
+        controller.play(request, debounce = debounce, debounceMillis = debounceMillis)
+        return false
+    }
+
+    fun playPreview(request: PlayerController.Request, debounce: Boolean): Boolean =
+        play(
+            request = request,
+            debounce = debounce,
+            debounceMillis = if (debounce) GUIDE_SWITCH_DEBOUNCE_MILLIS else null,
+        )
+
+    fun stop() {
+        pendingHandoff = null
+        handoffExpiryJob?.cancel()
+        handoffExpiryJob = null
+        controller.stop()
+    }
+
+    private companion object {
+        const val HANDOFF_TIMEOUT_MILLIS = 1_500L
+        const val GUIDE_SWITCH_DEBOUNCE_MILLIS = 700L
+    }
+}

--- a/app/src/main/java/app/opentv/player/PlayerController.kt
+++ b/app/src/main/java/app/opentv/player/PlayerController.kt
@@ -43,9 +43,9 @@ import okhttp3.OkHttpClient
  * nothing plays until the app is killed. That is the "changing channels too quickly causes
  * streams to fail" class of bug, and it is entirely self-inflicted.
  *
- * OpenTV keeps exactly one player for the lifetime of the screen and only ever swaps its
- * media item. Requests are debounced, and an in-flight switch is cancelled the moment a newer
- * one arrives, so holding channel-up costs one actual tune — the one the user stopped on.
+ * OpenTV keeps exactly one player for the lifetime of its owning playback session and only ever
+ * swaps its media item. Requests are debounced, and an in-flight switch is cancelled the moment a
+ * newer one arrives, so holding channel-up costs one actual tune — the one the user stopped on.
  */
 @OptIn(UnstableApi::class)
 class PlayerController(
@@ -259,14 +259,18 @@ class PlayerController(
      * @param debounce when true (the default for channel surfing) the switch waits briefly so
      * that rapid presses collapse into a single tune. Pass false for a deliberate selection.
      */
-    fun play(request: Request, debounce: Boolean = true) {
+    fun play(
+        request: Request,
+        debounce: Boolean = true,
+        debounceMillis: Long? = null,
+    ) {
         // Cancelling here is what makes fast channel-changing safe: the previous switch never
         // reaches the player, so we never stack prepares.
         switchJob?.cancel()
         current = request
 
         switchJob = scope.launch {
-            if (debounce) delay(switchDebounceMillis)
+            if (debounce) delay(debounceMillis ?: switchDebounceMillis)
 
             consecutiveFailures = 0
             httpFactory.setDefaultRequestProperties(mapOf("User-Agent" to request.userAgent))
@@ -302,6 +306,14 @@ class PlayerController(
 
     fun retry() {
         current?.let { play(it, debounce = false) }
+    }
+
+    /** Whether [request] is already the media item prepared by this player. */
+    fun canReuse(request: Request): Boolean {
+        val preparedUri = player.currentMediaItem?.localConfiguration?.uri?.toString()
+        return current?.url == request.url &&
+            preparedUri == request.url &&
+            (_state.value is State.Buffering || _state.value is State.Playing)
     }
 
     /**

--- a/app/src/main/java/app/opentv/ui/channels/GuideChannelActivationPolicy.kt
+++ b/app/src/main/java/app/opentv/ui/channels/GuideChannelActivationPolicy.kt
@@ -1,0 +1,23 @@
+/*
+ * This file is part of OpenTV.
+ * Copyright (C) 2026 The OpenTV Contributors
+ * Licensed under the GNU General Public License v3.0 or later.
+ */
+package app.opentv.ui.channels
+
+/** Pure remote-press policy kept outside Compose so short/long activation is unit-testable. */
+internal object GuideChannelActivationPolicy {
+    enum class Action {
+        WATCH,
+        OPEN_OPTIONS,
+    }
+
+    fun action(heldMillis: Long, systemReportedLongPress: Boolean): Action =
+        if (systemReportedLongPress || heldMillis >= LONG_PRESS_MILLIS) {
+            Action.OPEN_OPTIONS
+        } else {
+            Action.WATCH
+        }
+
+    const val LONG_PRESS_MILLIS = 500L
+}

--- a/app/src/main/java/app/opentv/ui/channels/GuideGrid.kt
+++ b/app/src/main/java/app/opentv/ui/channels/GuideGrid.kt
@@ -8,6 +8,8 @@ package app.opentv.ui.channels
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -24,6 +26,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -35,12 +38,16 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
@@ -61,6 +68,9 @@ import coil.compose.AsyncImage
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 /**
  * The programme guide: channels down the left, a scrolling time-line to the right, with
@@ -81,7 +91,11 @@ fun GuideGrid(
     rows: List<ChannelsViewModel.Row>,
     windowStartMillis: Long,
     selectedKey: Any?,
+    focusRequestKey: Any? = null,
+    focusRequestId: Int = 0,
     onSelectRow: (ChannelsViewModel.Row) -> Unit,
+    onOpenRowOptions: (ChannelsViewModel.Row) -> Unit,
+    onRowOptionsRelease: () -> Unit,
     onFocusRow: (ChannelsViewModel.Row) -> Unit,
     onProgramme: (ChannelsViewModel.Row, Programme) -> Unit = { _, _ -> },
     onToggleFavourite: (ChannelsViewModel.Row) -> Unit = {},
@@ -92,10 +106,20 @@ fun GuideGrid(
     modifier: Modifier = Modifier,
 ) {
     val scroll = rememberScrollState()
+    val listState = rememberLazyListState()
+    val returnFocus = remember { FocusRequester() }
+    var focusedRowKey by remember { mutableStateOf<Any?>(null) }
     val now = System.currentTimeMillis()
     // Jumping to another day resets the horizontal scroll to that day's start; a within-day time
     // drift (dayOffset unchanged) leaves the user's scroll position untouched.
     androidx.compose.runtime.LaunchedEffect(dayOffset) { scroll.scrollTo(0) }
+    androidx.compose.runtime.LaunchedEffect(focusRequestId, focusRequestKey) {
+        val index = rows.indexOfFirst { it.key == focusRequestKey }
+        if (focusRequestId > 0 && index >= 0) {
+            listState.scrollToItem(index)
+            requestGuideRowFocus(returnFocus) { focusedRowKey == focusRequestKey }
+        }
+    }
 
     Column(modifier.fillMaxSize()) {
         // No pager buttons: the programme blocks are d-pad focusable, so moving right along a row
@@ -103,6 +127,7 @@ fun GuideGrid(
         TimeHeader(windowStartMillis, scroll)
 
         LazyColumn(
+            state = listState,
             contentPadding = PaddingValues(bottom = 16.dp),
             verticalArrangement = Arrangement.spacedBy(3.dp),
         ) {
@@ -113,8 +138,14 @@ fun GuideGrid(
                     nowMillis = now,
                     scroll = scroll,
                     isSelected = row.key == selectedKey,
+                    focusRequester = if (row.key == focusRequestKey) returnFocus else null,
                     onSelect = { onSelectRow(row) },
-                    onFocus = { onFocusRow(row) },
+                    onOpenOptions = { onOpenRowOptions(row) },
+                    onOptionsRelease = onRowOptionsRelease,
+                    onFocus = {
+                        focusedRowKey = row.key
+                        onFocusRow(row)
+                    },
                     onProgramme = { programme -> onProgramme(row, programme) },
                     onToggleFavourite = { onToggleFavourite(row) },
                     onExitLeft = onExitLeftFromChannel,
@@ -135,15 +166,30 @@ fun GuideGrid(
 fun ChannelList(
     rows: List<ChannelsViewModel.Row>,
     selectedKey: Any?,
+    focusRequestKey: Any? = null,
+    focusRequestId: Int = 0,
     onSelectRow: (ChannelsViewModel.Row) -> Unit,
+    onOpenRowOptions: (ChannelsViewModel.Row) -> Unit,
+    onRowOptionsRelease: () -> Unit,
     onFocusRow: (ChannelsViewModel.Row) -> Unit,
     onToggleFavourite: (ChannelsViewModel.Row) -> Unit = {},
     onExitLeftFromChannel: () -> Boolean = { false },
     modifier: Modifier = Modifier,
 ) {
     val now = System.currentTimeMillis()
+    val listState = rememberLazyListState()
+    val returnFocus = remember { FocusRequester() }
+    var focusedRowKey by remember { mutableStateOf<Any?>(null) }
+    androidx.compose.runtime.LaunchedEffect(focusRequestId, focusRequestKey) {
+        val index = rows.indexOfFirst { it.key == focusRequestKey }
+        if (focusRequestId > 0 && index >= 0) {
+            listState.scrollToItem(index)
+            requestGuideRowFocus(returnFocus) { focusedRowKey == focusRequestKey }
+        }
+    }
     LazyColumn(
         modifier = modifier.fillMaxSize(),
+        state = listState,
         contentPadding = PaddingValues(vertical = 8.dp),
         verticalArrangement = Arrangement.spacedBy(3.dp),
     ) {
@@ -152,8 +198,14 @@ fun ChannelList(
                 row = row,
                 nowMillis = now,
                 isSelected = row.key == selectedKey,
+                focusRequester = if (row.key == focusRequestKey) returnFocus else null,
                 onSelect = { onSelectRow(row) },
-                onFocus = { onFocusRow(row) },
+                onOpenOptions = { onOpenRowOptions(row) },
+                onOptionsRelease = onRowOptionsRelease,
+                onFocus = {
+                    focusedRowKey = row.key
+                    onFocusRow(row)
+                },
                 onToggleFavourite = { onToggleFavourite(row) },
                 onExitLeft = onExitLeftFromChannel,
             )
@@ -166,7 +218,10 @@ private fun ChannelListRow(
     row: ChannelsViewModel.Row,
     nowMillis: Long,
     isSelected: Boolean,
+    focusRequester: FocusRequester?,
     onSelect: () -> Unit,
+    onOpenOptions: () -> Unit,
+    onOptionsRelease: () -> Unit,
     onFocus: () -> Unit,
     onToggleFavourite: () -> Unit,
     onExitLeft: () -> Boolean,
@@ -184,6 +239,7 @@ private fun ChannelListRow(
                 if (focused) Modifier.border(2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(8.dp))
                 else Modifier,
             )
+            .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
             // LEFT from a row reopens the collapsed rail, exactly like the grid's channel column.
             .onPreviewKeyEvent { e ->
                 if (e.type == KeyEventType.KeyDown && e.key == Key.DirectionLeft) onExitLeft() else false
@@ -192,7 +248,12 @@ private fun ChannelListRow(
                 focused = it.isFocused
                 if (it.isFocused) onFocus()
             }
-            .clickable(onClick = onSelect)
+            .guideChannelActivation(
+                enabled = focused,
+                onClick = onSelect,
+                onLongClick = onOpenOptions,
+                onLongClickRelease = onOptionsRelease,
+            )
             .padding(horizontal = 10.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -315,7 +376,10 @@ private fun GuideRow(
     nowMillis: Long,
     scroll: androidx.compose.foundation.ScrollState,
     isSelected: Boolean,
+    focusRequester: FocusRequester?,
     onSelect: () -> Unit,
+    onOpenOptions: () -> Unit,
+    onOptionsRelease: () -> Unit,
     onFocus: () -> Unit,
     onProgramme: (Programme) -> Unit,
     onToggleFavourite: () -> Unit = {},
@@ -342,6 +406,7 @@ private fun GuideRow(
                         2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(8.dp),
                     ) else Modifier,
                 )
+                .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
                 // LEFT from this leftmost column asks the host to reopen the collapsed category
                 // rail; onExitLeft consumes the key only when it handled it (rail was hidden), so
                 // moving left onto programme blocks and into an already-visible rail still works.
@@ -353,7 +418,12 @@ private fun GuideRow(
                     focused = it.isFocused
                     if (it.isFocused) onFocus()
                 }
-                .clickable(onClick = onSelect)
+                .guideChannelActivation(
+                    enabled = focused,
+                    onClick = onSelect,
+                    onLongClick = onOpenOptions,
+                    onLongClickRelease = onOptionsRelease,
+                )
                 .padding(horizontal = 10.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -526,6 +596,121 @@ private fun widthFor(fromMillis: Long, toMillis: Long): Dp {
 
 // A weak TV box will happily scroll this; the whole strip is ~12h * 60 * 4dp = ~2880dp wide.
 private const val MINUTE_DP = 4f
+/**
+ * Lazy rows are not guaranteed to have a focus target in the same frame as a scroll. Try
+ * again only while Compose rejects the request; once accepted, stop immediately so a fast user
+ * can move away with the d-pad without a later retry snapping focus back.
+ */
+private suspend fun requestGuideRowFocus(requester: FocusRequester, isTargetFocused: () -> Boolean) {
+    repeat(GUIDE_RETURN_FOCUS_ATTEMPTS) { attempt ->
+        if (isTargetFocused()) return
+        delay(if (attempt == 0) GUIDE_RETURN_INITIAL_DELAY_MILLIS else GUIDE_RETURN_RETRY_DELAY_MILLIS)
+        if (isTargetFocused()) return
+        runCatching { requester.requestFocus() }
+        delay(GUIDE_RETURN_SETTLE_DELAY_MILLIS)
+        if (isTargetFocused()) return
+    }
+}
+
+/**
+ * TV remotes report Select as key events, and Compose's pointer long-click detector does not
+ * consistently interpret Android TV key repeats. Start a timer on key-down so the menu opens as
+ * soon as the threshold is reached, without waiting for release. Native long-press/repeat events
+ * can trigger it earlier; key-up retains an elapsed-time fallback. Pointer/touch users still get
+ * combinedClickable.
+ * When the row's favourite child owns focus this handler is disabled, preserving the star action.
+ */
+@Composable
+@OptIn(ExperimentalFoundationApi::class)
+private fun Modifier.guideChannelActivation(
+    enabled: Boolean,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+    onLongClickRelease: () -> Unit,
+): Modifier {
+    val scope = rememberCoroutineScope()
+    var activeDownTimeMillis by remember { mutableLongStateOf(0L) }
+    var longPressTriggered by remember { mutableStateOf(false) }
+    var longPressJob by remember { mutableStateOf<Job?>(null) }
+    return onPreviewKeyEvent { event ->
+        if (!enabled || !event.key.isGuideSelectKey()) return@onPreviewKeyEvent false
+        when (event.type) {
+            KeyEventType.KeyDown -> {
+                val nativeEvent = event.nativeKeyEvent
+                if (activeDownTimeMillis != nativeEvent.downTime) {
+                    longPressJob?.cancel()
+                    activeDownTimeMillis = nativeEvent.downTime
+                    longPressTriggered = false
+                    val pressDownTimeMillis = nativeEvent.downTime
+                    longPressJob = scope.launch {
+                        delay(GuideChannelActivationPolicy.LONG_PRESS_MILLIS)
+                        if (
+                            activeDownTimeMillis == pressDownTimeMillis &&
+                            !longPressTriggered
+                        ) {
+                            longPressTriggered = true
+                            longPressJob = null
+                            onLongClick()
+                        }
+                    }
+                }
+                if (
+                    !longPressTriggered &&
+                    (nativeEvent.isLongPress || nativeEvent.repeatCount > 0)
+                ) {
+                    longPressJob?.cancel()
+                    longPressJob = null
+                    longPressTriggered = true
+                    onLongClick()
+                }
+                true
+            }
+            KeyEventType.KeyUp -> {
+                longPressJob?.cancel()
+                longPressJob = null
+                val wasLongPress = longPressTriggered
+                val heldMillis = (
+                    event.nativeKeyEvent.eventTime - activeDownTimeMillis
+                ).coerceAtLeast(0L)
+                activeDownTimeMillis = 0L
+                longPressTriggered = false
+                if (wasLongPress) {
+                    onLongClickRelease()
+                    return@onPreviewKeyEvent true
+                }
+                val action = GuideChannelActivationPolicy.action(
+                    heldMillis = heldMillis,
+                    systemReportedLongPress = false,
+                )
+                when (action) {
+                    GuideChannelActivationPolicy.Action.WATCH -> onClick()
+                    GuideChannelActivationPolicy.Action.OPEN_OPTIONS -> {
+                        onLongClick()
+                        // This fallback opens on key-up, so no later release event is coming.
+                        onLongClickRelease()
+                    }
+                }
+                true
+            }
+            else -> true
+        }
+    }.combinedClickable(
+        onClick = onClick,
+        onLongClick = {
+            // Pointer/touch long-clicks have no Select key-up for the dialog guard to observe.
+            onLongClick()
+            onLongClickRelease()
+        },
+    )
+}
+
+private fun Key.isGuideSelectKey(): Boolean =
+    this == Key.DirectionCenter || this == Key.Enter || this == Key.NumPadEnter
+
+private const val GUIDE_RETURN_FOCUS_ATTEMPTS = 6
+private const val GUIDE_RETURN_INITIAL_DELAY_MILLIS = 100L
+private const val GUIDE_RETURN_RETRY_DELAY_MILLIS = 250L
+private const val GUIDE_RETURN_SETTLE_DELAY_MILLIS = 50L
 private const val HOURS_IN_WINDOW = 24
 private const val HALF_HOUR_MS = 30 * 60 * 1000L
 private val CHANNEL_COLUMN = 220.dp

--- a/app/src/main/java/app/opentv/ui/channels/GuideGrid.kt
+++ b/app/src/main/java/app/opentv/ui/channels/GuideGrid.kt
@@ -25,7 +25,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -131,9 +131,11 @@ fun GuideGrid(
             contentPadding = PaddingValues(bottom = 16.dp),
             verticalArrangement = Arrangement.spacedBy(3.dp),
         ) {
-            items(rows, key = { it.key }) { row ->
+            itemsIndexed(rows, key = { _, row -> row.key }) { index, row ->
                 GuideRow(
                     row = row,
+                    isFirstRow = index == 0,
+                    isLastRow = index == rows.lastIndex,
                     windowStartMillis = windowStartMillis,
                     nowMillis = now,
                     scroll = scroll,
@@ -193,9 +195,11 @@ fun ChannelList(
         contentPadding = PaddingValues(vertical = 8.dp),
         verticalArrangement = Arrangement.spacedBy(3.dp),
     ) {
-        items(rows, key = { it.key }) { row ->
+        itemsIndexed(rows, key = { _, row -> row.key }) { index, row ->
             ChannelListRow(
                 row = row,
+                isFirstRow = index == 0,
+                isLastRow = index == rows.lastIndex,
                 nowMillis = now,
                 isSelected = row.key == selectedKey,
                 focusRequester = if (row.key == focusRequestKey) returnFocus else null,
@@ -216,6 +220,8 @@ fun ChannelList(
 @Composable
 private fun ChannelListRow(
     row: ChannelsViewModel.Row,
+    isFirstRow: Boolean,
+    isLastRow: Boolean,
     nowMillis: Long,
     isSelected: Boolean,
     focusRequester: FocusRequester?,
@@ -242,7 +248,13 @@ private fun ChannelListRow(
             .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
             // LEFT from a row reopens the collapsed rail, exactly like the grid's channel column.
             .onPreviewKeyEvent { e ->
-                if (e.type == KeyEventType.KeyDown && e.key == Key.DirectionLeft) onExitLeft() else false
+                when {
+                    e.type != KeyEventType.KeyDown -> false
+                    isFirstRow && e.key == Key.DirectionUp -> true
+                    isLastRow && e.key == Key.DirectionDown -> true
+                    e.key == Key.DirectionLeft -> onExitLeft()
+                    else -> false
+                }
             }
             .onFocusChanged {
                 focused = it.isFocused
@@ -372,6 +384,8 @@ private fun TimeHeader(windowStartMillis: Long, scroll: androidx.compose.foundat
 @Composable
 private fun GuideRow(
     row: ChannelsViewModel.Row,
+    isFirstRow: Boolean,
+    isLastRow: Boolean,
     windowStartMillis: Long,
     nowMillis: Long,
     scroll: androidx.compose.foundation.ScrollState,
@@ -389,7 +403,22 @@ private fun GuideRow(
     // channel the preview is playing — it only changes when you press OK.
     var focused by remember { mutableStateOf(false) }
 
-    Row(Modifier.fillMaxWidth().height(ROW_HEIGHT)) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .height(ROW_HEIGHT)
+            // Never let a held vertical direction fall out of the lazy guide at either edge.
+            // Without this boundary Compose's spatial search can choose MainScreen's global rail.
+            .onPreviewKeyEvent { event ->
+                val direction = event.key.guideVerticalDirection()
+                event.type == KeyEventType.KeyDown && direction != null &&
+                    GuideVerticalFocusBoundary.shouldConsume(
+                        blockUp = isFirstRow,
+                        blockDown = isLastRow,
+                        direction = direction,
+                    )
+            },
+    ) {
 
         // ---- Fixed channel cell (does not scroll) --------------------------------------
         Row(
@@ -610,6 +639,12 @@ private suspend fun requestGuideRowFocus(requester: FocusRequester, isTargetFocu
         delay(GUIDE_RETURN_SETTLE_DELAY_MILLIS)
         if (isTargetFocused()) return
     }
+}
+
+private fun Key.guideVerticalDirection(): GuideDirectionRepeatGate.Direction? = when (this) {
+    Key.DirectionUp -> GuideDirectionRepeatGate.Direction.UP
+    Key.DirectionDown -> GuideDirectionRepeatGate.Direction.DOWN
+    else -> null
 }
 
 /**

--- a/app/src/main/java/app/opentv/ui/channels/GuideNavigationPolicy.kt
+++ b/app/src/main/java/app/opentv/ui/channels/GuideNavigationPolicy.kt
@@ -1,0 +1,52 @@
+/*
+ * This file is part of OpenTV.
+ * Copyright (C) 2026 The OpenTV Contributors
+ * Licensed under the GNU General Public License v3.0 or later.
+ */
+package app.opentv.ui.channels
+
+/**
+ * Caps held vertical navigation at a rate the guide can render without building an input backlog.
+ *
+ * Android TV remotes are not consistent about repeat metadata: some preserve one key down-time and
+ * increment repeatCount, while others emit a rapid series of ordinary key downs. Event time is the
+ * reliable common signal, so repeated key downs in the same direction are coalesced regardless of
+ * how the remote labels them. A direction change is always accepted immediately.
+ */
+internal class GuideDirectionRepeatGate(
+    private val minimumIntervalMillis: Long = DEFAULT_INTERVAL_MILLIS,
+) {
+    enum class Direction { UP, DOWN }
+
+    private var lastAcceptedDirection: Direction? = null
+    private var lastAcceptedEventTimeMillis: Long = Long.MIN_VALUE
+
+    fun shouldConsume(direction: Direction, eventTimeMillis: Long): Boolean {
+        val elapsed = eventTimeMillis - lastAcceptedEventTimeMillis
+        if (direction != lastAcceptedDirection || elapsed < 0L || elapsed >= minimumIntervalMillis) {
+            lastAcceptedDirection = direction
+            lastAcceptedEventTimeMillis = eventTimeMillis
+            return false
+        }
+        return true
+    }
+
+    fun reset() {
+        lastAcceptedDirection = null
+        lastAcceptedEventTimeMillis = Long.MIN_VALUE
+    }
+
+    companion object {
+        const val DEFAULT_INTERVAL_MILLIS = 90L
+    }
+}
+
+internal object GuideVerticalFocusBoundary {
+    fun shouldConsume(
+        blockUp: Boolean,
+        blockDown: Boolean,
+        direction: GuideDirectionRepeatGate.Direction,
+    ): Boolean =
+        (blockUp && direction == GuideDirectionRepeatGate.Direction.UP) ||
+            (blockDown && direction == GuideDirectionRepeatGate.Direction.DOWN)
+}

--- a/app/src/main/java/app/opentv/ui/channels/GuidePreview.kt
+++ b/app/src/main/java/app/opentv/ui/channels/GuidePreview.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -68,12 +69,12 @@ import java.util.Locale
  * ## Inline video
  * When [previewPlayer] is non-null the highlighted channel plays, muted, inside the card. The
  * earlier version of this that locked up cheap boxes ran a *second* decoder behind the
- * full-screen one; here there is only ever this single, muted, debounced player — and the
- * caller ([HomeScreen]) stops it before handing off to full-screen and whenever the screen is
- * backgrounded, so the device never has two decoders alive at once. Low-end boxes can turn the
- * whole thing off in settings, in which case [previewPlayer] is null and this falls back to the
- * logo. The logo stays behind the video as the shutter, so a buffering or failed stream still
- * shows something rather than a black hole.
+ * full-screen one. The caller now supplies the process-level live player shared with full-screen:
+ * navigation only moves its output between PlayerViews, so there is still one decoder and the
+ * same-channel transition does not reopen the stream. Leaving live TV stops the shared session.
+ * Low-end boxes can turn the preview off in settings, in which case [previewPlayer] is null and
+ * this falls back to the logo. The logo stays behind the video as the shutter, so a buffering or
+ * failed stream still shows something rather than a black hole.
  */
 @OptIn(UnstableApi::class)
 @Composable
@@ -90,6 +91,7 @@ fun GuidePreview(
     canGoPrevDay: Boolean = false,
     onPrevDay: () -> Unit = {},
     onNextDay: () -> Unit = {},
+    watchFocusable: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -105,6 +107,10 @@ fun GuidePreview(
                 .aspectRatio(16f / 9f)
                 .clip(RoundedCornerShape(12.dp))
                 .background(Color.Black)
+                // Navigation remembers the preview card as the last focused control. While the
+                // guide is explicitly restoring a channel row after full-screen playback, keep
+                // that stale target out of focus search so it cannot immediately steal focus back.
+                .focusProperties { canFocus = watchFocusable }
                 .clickable(onClick = onWatch),
             contentAlignment = Alignment.Center,
         ) {

--- a/app/src/main/java/app/opentv/ui/channels/GuidePreview.kt
+++ b/app/src/main/java/app/opentv/ui/channels/GuidePreview.kt
@@ -8,7 +8,6 @@ package app.opentv.ui.channels
 import android.view.ViewGroup
 import androidx.annotation.OptIn
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -19,19 +18,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.FiberManualRecord
-import androidx.compose.material.icons.filled.KeyboardArrowLeft
-import androidx.compose.material.icons.filled.KeyboardArrowRight
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.Stop
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -63,8 +51,8 @@ import java.util.Locale
  *
  * As focus moves down the channel list, [row] follows it and the pane shows that channel's
  * logo alongside what's on now, how far through it is, what's next, and a synopsis when the
- * guide carries one — the "info on the EPG" people ask for before they'll judge a guide.
- * Pressing it plays the channel full-screen.
+ * guide carries one — the "info on the EPG" people ask for before they'll judge a guide. The
+ * pane is intentionally display-only so remote focus stays in the channel rows below it.
  *
  * ## Inline video
  * When [previewPlayer] is non-null the highlighted channel plays, muted, inside the card. The
@@ -81,17 +69,7 @@ import java.util.Locale
 fun GuidePreview(
     row: ChannelsViewModel.Row?,
     nowMillis: Long,
-    onWatch: () -> Unit,
-    onRefresh: () -> Unit,
-    onAddSource: () -> Unit,
     previewPlayer: ExoPlayer?,
-    isRecording: Boolean = false,
-    onRecord: () -> Unit = {},
-    dayLabel: String = "",
-    canGoPrevDay: Boolean = false,
-    onPrevDay: () -> Unit = {},
-    onNextDay: () -> Unit = {},
-    watchFocusable: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -100,18 +78,14 @@ fun GuidePreview(
             .height(212.dp)
             .padding(horizontal = 16.dp, vertical = 12.dp),
     ) {
-        // ---- Logo / "watch" card ----------------------------------------------------------
+        // ---- Display-only logo / live-preview card -----------------------------------------
         Box(
             Modifier
                 .fillMaxHeight()
                 .aspectRatio(16f / 9f)
                 .clip(RoundedCornerShape(12.dp))
                 .background(Color.Black)
-                // Navigation remembers the preview card as the last focused control. While the
-                // guide is explicitly restoring a channel row after full-screen playback, keep
-                // that stale target out of focus search so it cannot immediately steal focus back.
-                .focusProperties { canFocus = watchFocusable }
-                .clickable(onClick = onWatch),
+                .focusProperties { canFocus = false },
             contentAlignment = Alignment.Center,
         ) {
             // Logo sits behind everything as the fallback / shutter.
@@ -127,10 +101,14 @@ fun GuidePreview(
             // shutter means the logo behind shows through until the first frame arrives.
             if (previewPlayer != null && row != null) {
                 AndroidView(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier.fillMaxSize().focusProperties { canFocus = false },
                     factory = { ctx ->
                         PlayerView(ctx).apply {
                             useController = false
+                            isFocusable = false
+                            isFocusableInTouchMode = false
+                            isClickable = false
+                            descendantFocusability = ViewGroup.FOCUS_BLOCK_DESCENDANTS
                             resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
                             setShutterBackgroundColor(android.graphics.Color.TRANSPARENT)
                             setBackgroundColor(android.graphics.Color.TRANSPARENT)
@@ -144,76 +122,12 @@ fun GuidePreview(
                     update = { it.player = previewPlayer },
                 )
             }
-
-            Row(
-                Modifier
-                    .align(Alignment.BottomStart)
-                    .padding(10.dp)
-                    .background(Color.Black.copy(alpha = 0.55f), RoundedCornerShape(8.dp))
-                    .padding(horizontal = 8.dp, vertical = 4.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    Icons.Default.PlayArrow,
-                    contentDescription = null,
-                    tint = Color.White,
-                    modifier = Modifier.size(16.dp),
-                )
-                Spacer(Modifier.width(4.dp))
-                Text(stringResource(R.string.guide_watch_label), color = Color.White, style = MaterialTheme.typography.labelMedium)
-            }
         }
 
         Spacer(Modifier.width(18.dp))
 
         // ---- Now / next detail ------------------------------------------------------------
         Column(Modifier.weight(1f).fillMaxHeight()) {
-            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                // ---- Day navigation (Sky Q-style): ‹ Today › ----------------------------
-                // Only shown once the caller wires a label in; keeps older callers unchanged.
-                if (dayLabel.isNotEmpty()) {
-                    IconButton(onClick = onPrevDay, enabled = canGoPrevDay) {
-                        Icon(
-                            Icons.Default.KeyboardArrowLeft,
-                            contentDescription = stringResource(R.string.guide_prev_day),
-                            tint = if (canGoPrevDay) MaterialTheme.colorScheme.onSurface
-                            else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f),
-                        )
-                    }
-                    Text(
-                        dayLabel,
-                        style = MaterialTheme.typography.labelLarge,
-                        fontWeight = FontWeight.SemiBold,
-                        maxLines = 1,
-                    )
-                    IconButton(onClick = onNextDay) {
-                        Icon(
-                            Icons.Default.KeyboardArrowRight,
-                            contentDescription = stringResource(R.string.guide_next_day),
-                        )
-                    }
-                }
-                Spacer(Modifier.weight(1f))
-                if (row != null) {
-                    IconButton(onClick = onRecord) {
-                        // Red throughout — the record convention — but the glyph switches to a
-                        // stop square while a recording is running, so a press visibly does
-                        // something (● start → ■ stop) rather than looking inert.
-                        Icon(
-                            if (isRecording) Icons.Default.Stop else Icons.Default.FiberManualRecord,
-                            contentDescription = if (isRecording) stringResource(R.string.guide_cd_stop_recording) else stringResource(R.string.guide_cd_record_now),
-                            tint = Color(0xFFE53935),
-                        )
-                    }
-                }
-                IconButton(onClick = onRefresh) {
-                    Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.guide_cd_refresh))
-                }
-                IconButton(onClick = onAddSource) {
-                    Icon(Icons.Default.Add, contentDescription = stringResource(R.string.guide_cd_add_source))
-                }
-            }
-
             if (row == null) {
                 Box(Modifier.fillMaxSize(), contentAlignment = Alignment.CenterStart) {
                     Text(

--- a/app/src/main/java/app/opentv/ui/channels/GuidePreviewPolicy.kt
+++ b/app/src/main/java/app/opentv/ui/channels/GuidePreviewPolicy.kt
@@ -19,17 +19,6 @@ internal object GuidePreviewPolicy {
         AppSettings.GuidePreviewMode.HIGHLIGHTED_CHANNEL -> highlightedChannelId
     }
 
-    /** The Watch control belongs to the video card, so it must open the video actually shown. */
-    fun watchChannelId(
-        previewVisible: Boolean,
-        previewChannelId: Long?,
-        highlightedChannelId: Long?,
-    ): Long? = if (previewVisible) {
-        previewChannelId ?: highlightedChannelId
-    } else {
-        highlightedChannelId
-    }
-
     /** Finds the guide row containing the last full-screen channel, including quality variants. */
     fun returningRowIndex(
         currentChannelId: Long,

--- a/app/src/main/java/app/opentv/ui/channels/GuidePreviewPolicy.kt
+++ b/app/src/main/java/app/opentv/ui/channels/GuidePreviewPolicy.kt
@@ -29,4 +29,12 @@ internal object GuidePreviewPolicy {
     } else {
         highlightedChannelId
     }
+
+    /** Finds the guide row containing the last full-screen channel, including quality variants. */
+    fun returningRowIndex(
+        currentChannelId: Long,
+        rowChannelIds: List<Set<Long>>,
+    ): Int? = rowChannelIds
+        .indexOfFirst { currentChannelId > 0L && currentChannelId in it }
+        .takeIf { it >= 0 }
 }

--- a/app/src/main/java/app/opentv/ui/channels/GuidePreviewPolicy.kt
+++ b/app/src/main/java/app/opentv/ui/channels/GuidePreviewPolicy.kt
@@ -1,0 +1,32 @@
+/*
+ * This file is part of OpenTV.
+ * Copyright (C) 2026 The OpenTV Contributors
+ * Licensed under the GNU General Public License v3.0 or later.
+ */
+package app.opentv.ui.channels
+
+import app.opentv.core.AppSettings
+
+/** Pure selection policy kept outside Compose so the guide-preview contract is unit-testable. */
+internal object GuidePreviewPolicy {
+    fun channelId(
+        mode: AppSettings.GuidePreviewMode,
+        currentChannelId: Long,
+        highlightedChannelId: Long?,
+    ): Long? = when (mode) {
+        AppSettings.GuidePreviewMode.CURRENT_CHANNEL ->
+            currentChannelId.takeIf { it > 0L } ?: highlightedChannelId
+        AppSettings.GuidePreviewMode.HIGHLIGHTED_CHANNEL -> highlightedChannelId
+    }
+
+    /** The Watch control belongs to the video card, so it must open the video actually shown. */
+    fun watchChannelId(
+        previewVisible: Boolean,
+        previewChannelId: Long?,
+        highlightedChannelId: Long?,
+    ): Long? = if (previewVisible) {
+        previewChannelId ?: highlightedChannelId
+    } else {
+        highlightedChannelId
+    }
+}

--- a/app/src/main/java/app/opentv/ui/channels/HomeScreen.kt
+++ b/app/src/main/java/app/opentv/ui/channels/HomeScreen.kt
@@ -1031,7 +1031,6 @@ fun HomeScreen(
                     if (recordingThis != null) {
                         RecordActionRow(
                             stringResource(R.string.rec_stop_recording),
-                            primary = true,
                             blockActivation = guardChannelMenuSelectUntilRelease,
                         ) {
                             graph.recordingEngine.stop(recordingThis.id)
@@ -1041,7 +1040,6 @@ fun HomeScreen(
                     } else {
                         RecordActionRow(
                             stringResource(R.string.guide_record_now_playing),
-                            primary = true,
                             blockActivation = guardChannelMenuSelectUntilRelease,
                         ) {
                             recordScope.launch { graph.recordingEngine.startChannel(channel, nowProg) }

--- a/app/src/main/java/app/opentv/ui/channels/HomeScreen.kt
+++ b/app/src/main/java/app/opentv/ui/channels/HomeScreen.kt
@@ -154,7 +154,6 @@ fun HomeScreen(
     var returnFilterResetAttempted by remember { mutableStateOf(false) }
     var guideFocusTargetKey by remember { mutableStateOf<Any?>(null) }
     var guideFocusRequestId by remember { mutableIntStateOf(0) }
-    var awaitingGuideRowFocus by remember { mutableStateOf(true) }
     val previewSound by settings.guidePreviewSound.collectAsState()
     var nowMillis by remember { mutableLongStateOf(System.currentTimeMillis()) }
 
@@ -289,7 +288,6 @@ fun HomeScreen(
             target?.let {
                 railExpanded = false
                 guideFocusTargetKey = it.key
-                awaitingGuideRowFocus = true
                 guideFocusRequestId++
             }
         } else {
@@ -380,11 +378,6 @@ fun HomeScreen(
         highlightedChannelId = highlightedChannel?.id,
     )
     val previewVisible = previewEnabled && !recordingActive
-    val watchChannelId = GuidePreviewPolicy.watchChannelId(
-        previewVisible = previewVisible,
-        previewChannelId = previewChannelId,
-        highlightedChannelId = highlightedChannel?.id,
-    )
     LaunchedEffect(
         previewChannelId,
         previewEnabled,
@@ -594,64 +587,16 @@ fun HomeScreen(
                     else -> EmptyState(onAddSource)
                 }
             } else {
-                // Hand the player the list you're browsing so it can zap channel up/down.
-                fun goFullscreen(channel: Channel) = requestLive(channel)
-
-                // Record the highlighted channel's now-programme (bounded to its end), or stop it
-                // if it's already recording. Powers the preview pane's quick record dot.
-                fun recordSelected() {
-                    val row = highlightedRow ?: return
-                    val active = activeRecordings.firstOrNull { it.channelId == row.primary.id }
-                    if (active != null) {
-                        graph.recordingEngine.stop(active.id)
-                        Toast.makeText(context, context.getString(R.string.rec_recording_stopped), Toast.LENGTH_SHORT).show()
-                    } else {
-                        recordScope.launch { graph.recordingEngine.startChannel(row.primary, row.now) }
-                        Toast.makeText(context, context.getString(R.string.rec_recording_started_see_tab, row.primary.shownName), Toast.LENGTH_LONG).show()
-                        promptBackgroundIfNeeded()
-                    }
-                }
-
-                val dayLabel = when (guideDayOffset) {
-                    0 -> stringResource(R.string.guide_today)
-                    1 -> stringResource(R.string.guide_tomorrow)
-                    else -> remember(windowStart) {
-                        SimpleDateFormat("EEE d MMM", Locale.getDefault()).format(Date(windowStart))
-                    }
-                }
                 GuidePreview(
                     row = highlightedRow,
                     nowMillis = nowMillis,
-                    onWatch = {
-                        watchChannelId?.let { id ->
-                            if (id == highlightedChannel?.id) {
-                                highlightedChannel?.let(::goFullscreen)
-                            } else {
-                                recordScope.launch {
-                                    graph.catalogRepository.channel(id)?.let(::goFullscreen)
-                                }
-                            }
-                        }
-                    },
-                    onRefresh = onRefresh,
-                    onAddSource = onAddSource,
                     previewPlayer = if (previewVisible && screenResumed) previewController.player else null,
-                    isRecording = highlightedRow?.primary?.id?.let { id ->
-                        activeRecordings.any { it.channelId == id }
-                    } == true,
-                    onRecord = { recordSelected() },
-                    dayLabel = dayLabel,
-                    canGoPrevDay = guideDayOffset > 0,
-                    onPrevDay = { viewModel.nudgeGuideDay(-1) },
-                    onNextDay = { viewModel.nudgeGuideDay(1) },
-                    watchFocusable = !awaitingGuideRowFocus,
                 )
                 // Shared by both layouts: focus follows the highlight and collapses the rail; LEFT
                 // from the leftmost element reopens the rail (consumed only when it was hidden).
                 val onFocusChannel: (ChannelsViewModel.Row) -> Unit = {
                     highlightedRow = it
                     railExpanded = false
-                    if (it.key == guideFocusTargetKey) awaitingGuideRowFocus = false
                     pendingRailFocus = false
                 }
                 val onExitLeftChannel: () -> Boolean = {

--- a/app/src/main/java/app/opentv/ui/channels/HomeScreen.kt
+++ b/app/src/main/java/app/opentv/ui/channels/HomeScreen.kt
@@ -8,6 +8,7 @@ package app.opentv.ui.channels
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -28,6 +29,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
@@ -208,18 +210,39 @@ fun HomeScreen(
         label = "railWidth",
     )
     val railFocusRequester = remember { FocusRequester() }
-    // Set when LEFT reopens the rail; the effect waits for the rail to be laid out again before
-    // moving focus onto it — a just-revealed node isn't focusable on the very same frame.
+    val railListState = rememberLazyListState()
+    var railHasFocus by remember { mutableStateOf(false) }
+    // Set when LEFT reopens the rail. It remains true until the rail confirms that one of its
+    // entries owns focus, so another LEFT cannot escape to the app-wide navigation rail while the
+    // width animation or a busy guide frame is still in progress.
     var pendingRailFocus by remember { mutableStateOf(false) }
-    LaunchedEffect(pendingRailFocus) {
-        if (pendingRailFocus) {
-            delay(50)
-            // runCatching: if the selected category is scrolled out of the rail's list it may not
-            // be composed; a second LEFT press then still reaches the rail by ordinary navigation.
-            runCatching { railFocusRequester.requestFocus() }
-            pendingRailFocus = false
+    val railFocusCategoryKey = remember(selectedCategory, categories) {
+        selectedCategory?.takeIf { selected -> categories.any { it.key == selected } }
+    }
+    val selectedRailIndex = remember(sources, favouritesOnly, railFocusCategoryKey, categories) {
+        val providerPrefix = if (sources.size > 1) sources.size + 3 else 0
+        when {
+            favouritesOnly -> providerPrefix
+            railFocusCategoryKey == null -> providerPrefix + 1
+            else -> {
+                val categoryIndex = categories.indexOfFirst { it.key == railFocusCategoryKey }
+                providerPrefix + 2 + categoryIndex
+            }
         }
     }
+    LaunchedEffect(pendingRailFocus, selectedRailIndex) {
+        while (pendingRailFocus && !railHasFocus) {
+            // The selected category can be outside the lazy rail's composed viewport. Bring it
+            // into composition first, then retry focus after layout until the rail confirms it.
+            runCatching { railListState.scrollToItem(selectedRailIndex) }
+            delay(RAIL_FOCUS_RETRY_MILLIS)
+            runCatching { railFocusRequester.requestFocus() }
+            delay(RAIL_FOCUS_RETRY_MILLIS)
+        }
+        if (railHasFocus) pendingRailFocus = false
+    }
+
+    val directionRepeatGate = remember { GuideDirectionRepeatGate() }
 
     // Re-evaluate "now" once a minute so progress bars advance without leaving the screen.
     LaunchedEffect(Unit) {
@@ -418,11 +441,30 @@ fun HomeScreen(
             // event halves here and navigate on key-up so guide Back resumes the last watched
             // channel without leaking into either MainScreen or the newly-opened PlayerScreen.
             .onPreviewKeyEvent { event ->
-                if (guideBackEnabled && (event.key == Key.Back || event.key == Key.Escape)) {
-                    if (event.type == KeyEventType.KeyUp) returnToCurrentChannel()
-                    true
-                } else {
-                    false
+                val verticalDirection = when (event.key) {
+                    Key.DirectionUp -> GuideDirectionRepeatGate.Direction.UP
+                    Key.DirectionDown -> GuideDirectionRepeatGate.Direction.DOWN
+                    else -> null
+                }
+                when {
+                    // Consume both halves of LEFT while the inner rail is taking focus. This is
+                    // the containment boundary that prevents fallback focus search from reaching
+                    // MainScreen's OpenTV / Live TV / Recordings rail.
+                    pendingRailFocus && event.key == Key.DirectionLeft -> true
+                    guideBackEnabled && (event.key == Key.Back || event.key == Key.Escape) -> {
+                        if (event.type == KeyEventType.KeyUp) returnToCurrentChannel()
+                        true
+                    }
+                    event.type == KeyEventType.KeyDown && verticalDirection != null &&
+                        directionRepeatGate.shouldConsume(
+                            direction = verticalDirection,
+                            eventTimeMillis = event.nativeKeyEvent.eventTime,
+                        ) -> true
+                    event.type == KeyEventType.KeyDown && verticalDirection == null -> {
+                        directionRepeatGate.reset()
+                        false
+                    }
+                    else -> false
                 }
             },
     ) {
@@ -436,6 +478,11 @@ fun HomeScreen(
                 .fillMaxHeight()
                 .background(MaterialTheme.colorScheme.surface)
                 .clipToBounds()
+                .focusGroup()
+                .onFocusChanged {
+                    railHasFocus = it.hasFocus
+                    if (it.hasFocus) pendingRailFocus = false
+                }
                 .padding(vertical = 16.dp),
         ) {
             Text(
@@ -447,6 +494,7 @@ fun HomeScreen(
             // The top "Search channels" bar was removed — Search now lives in the global nav rail.
 
             LazyColumn(
+                state = railListState,
                 contentPadding = PaddingValues(horizontal = 10.dp, vertical = 4.dp),
                 verticalArrangement = Arrangement.spacedBy(2.dp),
             ) {
@@ -466,6 +514,7 @@ fun HomeScreen(
                             label = stringResource(R.string.channels_manager_all_sources),
                             selected = selectedSource == null,
                             onClick = { viewModel.selectSource(null) },
+                            modifier = Modifier.containRailVerticalFocus(blockUp = true),
                         )
                     }
                     items(sources, key = { "src-${it.id}" }) { source ->
@@ -484,16 +533,27 @@ fun HomeScreen(
                         label = stringResource(R.string.guide_favourites),
                         selected = favouritesOnly,
                         onClick = viewModel::selectFavourites,
-                        modifier = if (favouritesOnly) Modifier.focusRequester(railFocusRequester) else Modifier,
+                        modifier = Modifier
+                            .containRailVerticalFocus(blockUp = sources.size <= 1)
+                            .then(
+                                if (favouritesOnly) Modifier.focusRequester(railFocusRequester)
+                                else Modifier,
+                            ),
                     )
                 }
                 item {
                     val allSelected = !favouritesOnly && selectedCategory == null
+                    val allReceivesFocus = !favouritesOnly && railFocusCategoryKey == null
                     RailEntry(
                         label = stringResource(R.string.guide_all_channels),
                         selected = allSelected,
                         onClick = { viewModel.selectCategory(null) },
-                        modifier = if (allSelected) Modifier.focusRequester(railFocusRequester) else Modifier,
+                        modifier = Modifier
+                            .containRailVerticalFocus(blockDown = categories.isEmpty())
+                            .then(
+                                if (allReceivesFocus) Modifier.focusRequester(railFocusRequester)
+                                else Modifier,
+                            ),
                     )
                 }
                 items(categories, key = { it.key }) { group ->
@@ -502,7 +562,15 @@ fun HomeScreen(
                         label = group.label,
                         selected = groupSelected,
                         onClick = { viewModel.selectCategory(group.key) },
-                        modifier = if (groupSelected) Modifier.focusRequester(railFocusRequester) else Modifier,
+                        modifier = Modifier
+                            .containRailVerticalFocus(blockDown = group.key == categories.lastOrNull()?.key)
+                            .then(
+                                if (!favouritesOnly && group.key == railFocusCategoryKey) {
+                                    Modifier.focusRequester(railFocusRequester)
+                                } else {
+                                    Modifier
+                                },
+                            ),
                     )
                 }
             }
@@ -584,9 +652,10 @@ fun HomeScreen(
                     highlightedRow = it
                     railExpanded = false
                     if (it.key == guideFocusTargetKey) awaitingGuideRowFocus = false
+                    pendingRailFocus = false
                 }
                 val onExitLeftChannel: () -> Boolean = {
-                    if (!railExpanded) {
+                    if (!railHasFocus) {
                         railExpanded = true
                         pendingRailFocus = true
                         true
@@ -1024,6 +1093,19 @@ fun HomeScreen(
 private fun Key.isChannelMenuSelectKey(): Boolean =
     this == Key.DirectionCenter || this == Key.Enter || this == Key.NumPadEnter
 
+private fun Modifier.containRailVerticalFocus(
+    blockUp: Boolean = false,
+    blockDown: Boolean = false,
+): Modifier = onPreviewKeyEvent { event ->
+    val direction = when (event.key) {
+        Key.DirectionUp -> GuideDirectionRepeatGate.Direction.UP
+        Key.DirectionDown -> GuideDirectionRepeatGate.Direction.DOWN
+        else -> null
+    }
+    event.type == KeyEventType.KeyDown && direction != null &&
+        GuideVerticalFocusBoundary.shouldConsume(blockUp, blockDown, direction)
+}
+
 /** Inserts a reminder for a future programme and arms its alarm. No-op if one already exists. */
 private suspend fun setReminder(
     graph: ServiceLocator.Graph,
@@ -1330,6 +1412,7 @@ private fun EmptyState(onAddSource: () -> Unit) {
 
 /** UTC in the database, device zone on screen. Converted here and nowhere else. */
 private const val CHANNEL_MENU_RELEASE_TAIL_MILLIS = 300L
+private const val RAIL_FOCUS_RETRY_MILLIS = 16L
 private val timeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
 
 private fun formatTime(utcMillis: Long): String = timeFormat.format(Date(utcMillis))

--- a/app/src/main/java/app/opentv/ui/channels/HomeScreen.kt
+++ b/app/src/main/java/app/opentv/ui/channels/HomeScreen.kt
@@ -121,6 +121,7 @@ fun HomeScreen(
     val graph = remember { ServiceLocator.get(context) }
     val settings = remember { graph.settings }
     val previewEnabled by settings.guidePreviewVideo.collectAsState()
+    val previewMode by settings.guidePreviewMode.collectAsState()
     val channelLayout by settings.channelLayout.collectAsState()
 
     val categories by viewModel.visibleCategoryGroups.collectAsState()
@@ -136,12 +137,11 @@ fun HomeScreen(
     // empty. Drives the choice between the loading spinner and a recoverable error below.
     val channelsPresent by viewModel.channelsPresent.collectAsState()
 
-    // Two separate ideas, on purpose:
-    //  - highlightedRow: where the d-pad is in the grid. Moves freely with up/down.
-    //  - selectedRow: what the preview pane plays. Only changes when you press OK, so scrolling
-    //    the list is calm and silent instead of re-tuning a stream on every keypress.
+    // The highlight is where the d-pad is in the grid. The preview stream is selected separately:
+    // by default it remains on the last full-screen channel, with focus-following available as a
+    // setting for viewers who prefer the old browse-to-preview behaviour.
     var highlightedRow by remember { mutableStateOf<ChannelsViewModel.Row?>(null) }
-    var selectedRow by remember { mutableStateOf<ChannelsViewModel.Row?>(null) }
+    var currentChannelId by remember { mutableLongStateOf(settings.lastChannelId) }
     val previewSound by settings.guidePreviewSound.collectAsState()
     var nowMillis by remember { mutableLongStateOf(System.currentTimeMillis()) }
 
@@ -195,11 +195,9 @@ fun HomeScreen(
         }
     }
 
-    // Keep both valid as the list changes (e.g. switching category): stay on the same channel if
-    // it's still present, otherwise fall back to the top of the new list.
+    // Keep the browsing highlight valid as the list changes (for example, switching category).
     LaunchedEffect(rows) {
         highlightedRow = rows.firstOrNull { it.key == highlightedRow?.key } ?: rows.firstOrNull()
-        selectedRow = rows.firstOrNull { it.key == selectedRow?.key } ?: rows.firstOrNull()
     }
 
     // ---- Live preview player -----------------------------------------------------------------
@@ -238,7 +236,12 @@ fun HomeScreen(
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             when (event) {
-                Lifecycle.Event.ON_RESUME -> screenResumed = true
+                Lifecycle.Event.ON_RESUME -> {
+                    // PlayerScreen writes this before playback begins. Re-read it every time the
+                    // guide returns so Back immediately restores that same channel in the preview.
+                    currentChannelId = settings.lastChannelId
+                    screenResumed = true
+                }
                 Lifecycle.Event.ON_PAUSE -> {
                     screenResumed = false
                     previewController.stop()
@@ -262,23 +265,47 @@ fun HomeScreen(
         onDispose { window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON) }
     }
 
-    // Preview audio follows the setting; muted by default so browsing stays quiet.
+    // Preview audio follows the existing sound setting.
     LaunchedEffect(previewSound) {
         previewController.player.volume = if (previewSound) 1f else 0f
     }
 
-    // Tune the preview to the highlighted channel, so it follows the d-pad as you browse — the
-    // standard TV-guide behaviour. Debounced, so holding a direction doesn't re-tune every step.
+    // By default the preview returns to the channel that was playing full-screen and stays there
+    // while focus moves through the guide. The alternate setting follows the highlighted channel;
+    // only that mode is debounced so holding a direction doesn't re-tune every step.
     // While a recording is running the preview is silenced entirely: on a single-connection line a
     // muted preview is still a second stream, which fights the recording and risks a provider ban.
     val recordingActive = activeRecordings.isNotEmpty()
-    LaunchedEffect(highlightedRow?.key, previewEnabled, screenResumed, recordingActive) {
-        val row = highlightedRow
-        if (!previewEnabled || !screenResumed || recordingActive || row == null) {
+    val highlightedChannel = highlightedRow?.primary
+    val previewChannelId = GuidePreviewPolicy.channelId(
+        mode = previewMode,
+        currentChannelId = currentChannelId,
+        highlightedChannelId = highlightedChannel?.id,
+    )
+    val previewVisible = previewEnabled && !recordingActive
+    val watchChannelId = GuidePreviewPolicy.watchChannelId(
+        previewVisible = previewVisible,
+        previewChannelId = previewChannelId,
+        highlightedChannelId = highlightedChannel?.id,
+    )
+    LaunchedEffect(
+        previewChannelId,
+        previewEnabled,
+        screenResumed,
+        recordingActive,
+    ) {
+        if (!previewEnabled || !screenResumed || recordingActive || previewChannelId == null) {
             previewController.stop()
             return@LaunchedEffect
         }
-        val channel = row.primary
+        val channel = if (previewChannelId == highlightedChannel?.id) {
+            highlightedChannel
+        } else {
+            graph.catalogRepository.channel(previewChannelId)
+        } ?: highlightedChannel ?: run {
+            previewController.stop()
+            return@LaunchedEffect
+        }
         val source = graph.sourceRepository.byId(channel.sourceId)
         previewController.play(
             PlayerController.Request(
@@ -287,7 +314,7 @@ fun HomeScreen(
                 userAgent = source?.userAgent ?: "OpenTV/0.1 (Android)",
                 isLive = true,
             ),
-            debounce = true,
+            debounce = previewMode == AppSettings.GuidePreviewMode.HIGHLIGHTED_CHANNEL,
         )
     }
 
@@ -420,10 +447,20 @@ fun HomeScreen(
                 GuidePreview(
                     row = highlightedRow,
                     nowMillis = nowMillis,
-                    onWatch = { highlightedRow?.let { goFullscreen(it.primary) } },
+                    onWatch = {
+                        watchChannelId?.let { id ->
+                            if (id == highlightedChannel?.id) {
+                                highlightedChannel?.let(::goFullscreen)
+                            } else {
+                                recordScope.launch {
+                                    graph.catalogRepository.channel(id)?.let(::goFullscreen)
+                                }
+                            }
+                        }
+                    },
                     onRefresh = onRefresh,
                     onAddSource = onAddSource,
-                    previewPlayer = if (previewEnabled && !recordingActive) previewController.player else null,
+                    previewPlayer = if (previewVisible) previewController.player else null,
                     isRecording = highlightedRow?.primary?.id?.let { id ->
                         activeRecordings.any { it.channelId == id }
                     } == true,

--- a/app/src/main/java/app/opentv/ui/channels/HomeScreen.kt
+++ b/app/src/main/java/app/opentv/ui/channels/HomeScreen.kt
@@ -992,6 +992,19 @@ fun HomeScreen(
                         requestLive(channel)
                     }
                     RecordActionRow(
+                        stringResource(
+                            if (channel.favourite) {
+                                R.string.common_remove_favourite
+                            } else {
+                                R.string.common_favourite
+                            },
+                        ),
+                        blockActivation = guardChannelMenuSelectUntilRelease,
+                    ) {
+                        viewModel.toggleFavourite(menuRow)
+                        channelMenu = null
+                    }
+                    RecordActionRow(
                         stringResource(R.string.guide_open_external),
                         blockActivation = guardChannelMenuSelectUntilRelease,
                     ) {

--- a/app/src/main/java/app/opentv/ui/channels/HomeScreen.kt
+++ b/app/src/main/java/app/opentv/ui/channels/HomeScreen.kt
@@ -8,6 +8,7 @@ package app.opentv.ui.channels
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -43,6 +44,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -53,6 +55,11 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -81,6 +88,7 @@ import app.opentv.data.model.shownName
 import app.opentv.reminders.ReminderScheduler
 import app.opentv.player.PlaybackQueue
 import app.opentv.player.PlayerController
+import app.opentv.player.LivePlaybackSession
 import app.opentv.ui.ChannelsViewModel
 import app.opentv.ui.RecordingBackgroundDialog
 import app.opentv.ui.RecordingBackgroundPrompt
@@ -88,10 +96,7 @@ import coil.compose.AsyncImage
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -120,6 +125,7 @@ fun HomeScreen(
     val context = LocalContext.current
     val graph = remember { ServiceLocator.get(context) }
     val settings = remember { graph.settings }
+    val liveSession = remember { graph.livePlaybackSession }
     val previewEnabled by settings.guidePreviewVideo.collectAsState()
     val previewMode by settings.guidePreviewMode.collectAsState()
     val channelLayout by settings.channelLayout.collectAsState()
@@ -142,6 +148,11 @@ fun HomeScreen(
     // setting for viewers who prefer the old browse-to-preview behaviour.
     var highlightedRow by remember { mutableStateOf<ChannelsViewModel.Row?>(null) }
     var currentChannelId by remember { mutableLongStateOf(settings.lastChannelId) }
+    var pendingGuideReturnSelection by remember { mutableStateOf(true) }
+    var returnFilterResetAttempted by remember { mutableStateOf(false) }
+    var guideFocusTargetKey by remember { mutableStateOf<Any?>(null) }
+    var guideFocusRequestId by remember { mutableIntStateOf(0) }
+    var awaitingGuideRowFocus by remember { mutableStateOf(true) }
     val previewSound by settings.guidePreviewSound.collectAsState()
     var nowMillis by remember { mutableLongStateOf(System.currentTimeMillis()) }
 
@@ -152,6 +163,30 @@ fun HomeScreen(
     var recordTarget by remember { mutableStateOf<Pair<ChannelsViewModel.Row, Programme>?>(null) }
     // The channel whose OK menu (Watch / Record / Schedule) is open.
     var channelMenu by remember { mutableStateOf<ChannelsViewModel.Row?>(null) }
+    // A held Select opens the dialog before release. While true, the dialog consumes that same
+    // press's repeats and key-up so its initially focused Watch action cannot activate itself.
+    var guardChannelMenuSelectUntilRelease by remember { mutableStateOf(false) }
+    var channelMenuReleaseJob by remember { mutableStateOf<Job?>(null) }
+    fun armChannelMenuSelectGuard() {
+        channelMenuReleaseJob?.cancel()
+        channelMenuReleaseJob = null
+        guardChannelMenuSelectUntilRelease = true
+    }
+    fun releaseChannelMenuSelectGuardAfterEventTail() {
+        channelMenuReleaseJob?.cancel()
+        channelMenuReleaseJob = recordScope.launch {
+            // Compose can synthesize the focused row's click immediately after key-up. Keep every
+            // menu action inert until that tail of the original held press has drained.
+            delay(CHANNEL_MENU_RELEASE_TAIL_MILLIS)
+            guardChannelMenuSelectUntilRelease = false
+            channelMenuReleaseJob = null
+        }
+    }
+    fun clearChannelMenuSelectGuard() {
+        channelMenuReleaseJob?.cancel()
+        channelMenuReleaseJob = null
+        guardChannelMenuSelectUntilRelease = false
+    }
 
     // First time the user records or schedules while OpenTV isn't exempt from battery optimisation,
     // offer the exemption so the capture survives standby. Once per session; never blocks recording.
@@ -195,24 +230,59 @@ fun HomeScreen(
         }
     }
 
-    // Keep the browsing highlight valid as the list changes (for example, switching category).
-    LaunchedEffect(rows) {
-        highlightedRow = rows.firstOrNull { it.key == highlightedRow?.key } ?: rows.firstOrNull()
+    // Returning from full-screen playback selects and focuses the row that contains the channel
+    // just watched. If a category/provider filter hides it, return once to All channels so the
+    // promised target is actually available. Later EPG refreshes preserve normal browsing focus.
+    LaunchedEffect(
+        rows,
+        pendingGuideReturnSelection,
+        currentChannelId,
+        selectedSource,
+        selectedCategory,
+        favouritesOnly,
+    ) {
+        if (rows.isEmpty()) return@LaunchedEffect
+        if (pendingGuideReturnSelection) {
+            val currentIndex = GuidePreviewPolicy.returningRowIndex(
+                currentChannelId = currentChannelId,
+                rowChannelIds = rows.map { row ->
+                    buildSet {
+                        add(row.primary.id)
+                        row.variants.forEach { add(it.id) }
+                    }
+                },
+            )
+            val filterActive = selectedSource != null || selectedCategory != null || favouritesOnly
+            if (currentChannelId > 0L && currentIndex == null && filterActive && !returnFilterResetAttempted) {
+                returnFilterResetAttempted = true
+                viewModel.selectSource(null)
+                return@LaunchedEffect
+            }
+            val target = currentIndex?.let(rows::get)
+                ?: rows.firstOrNull { it.key == highlightedRow?.key }
+                ?: rows.firstOrNull()
+            highlightedRow = target
+            pendingGuideReturnSelection = false
+            target?.let {
+                railExpanded = false
+                guideFocusTargetKey = it.key
+                awaitingGuideRowFocus = true
+                guideFocusRequestId++
+            }
+        } else {
+            highlightedRow = rows.firstOrNull { it.key == highlightedRow?.key } ?: rows.firstOrNull()
+        }
     }
 
     // ---- Live preview player -----------------------------------------------------------------
-    // One muted player, reused. It only ever decodes while the guide is the foreground screen,
-    // and is stopped before any hand-off to full-screen, so the box never runs two decoders at
-    // once — the thing that used to lock up cheap sticks.
-    val previewScope = remember { CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate) }
-    val previewController = remember {
-        PlayerController(context, previewScope, graph.httpClient, subtitlesEnabled = false, preview = true)
-            .also { it.player.volume = 0f }
-    }
+    // The guide and full-screen destination share this controller. Only the PlayerView changes,
+    // so returning to the current channel can retain its decoder, media item and buffered data.
+    val previewController = liveSession.controller
     DisposableEffect(Unit) {
+        liveSession.attach(LivePlaybackSession.Surface.GUIDE)
+        previewController.disableText()
         onDispose {
-            previewController.release()
-            previewScope.cancel()
+            liveSession.detach(LivePlaybackSession.Surface.GUIDE)
         }
     }
 
@@ -224,7 +294,7 @@ fun HomeScreen(
         PlaybackQueue.items = rows.map {
             PlaybackQueue.Item(it.primary.id, it.primary.shownName, it.primary.logoUrl, it.primary.number)
         }
-        previewController.stop()
+        liveSession.prepareHandoff(LivePlaybackSession.Surface.PLAYER)
         onPlayChannel(channel)
     }
     fun requestLive(channel: Channel) {
@@ -237,14 +307,18 @@ fun HomeScreen(
         val observer = LifecycleEventObserver { _, event ->
             when (event) {
                 Lifecycle.Event.ON_RESUME -> {
+                    liveSession.attach(LivePlaybackSession.Surface.GUIDE)
+                    previewController.disableText()
                     // PlayerScreen writes this before playback begins. Re-read it every time the
-                    // guide returns so Back immediately restores that same channel in the preview.
+                    // guide returns so Back restores that channel in both the preview and focus.
                     currentChannelId = settings.lastChannelId
+                    returnFilterResetAttempted = false
+                    pendingGuideReturnSelection = true
                     screenResumed = true
                 }
                 Lifecycle.Event.ON_PAUSE -> {
                     screenResumed = false
-                    previewController.stop()
+                    liveSession.detach(LivePlaybackSession.Surface.GUIDE)
                 }
                 else -> Unit
             }
@@ -265,9 +339,9 @@ fun HomeScreen(
         onDispose { window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON) }
     }
 
-    // Preview audio follows the existing sound setting.
-    LaunchedEffect(previewSound) {
-        previewController.player.volume = if (previewSound) 1f else 0f
+    // Preview audio follows the setting. It defaults on so Back keeps the current channel audible.
+    LaunchedEffect(previewSound, screenResumed) {
+        if (screenResumed) previewController.player.volume = if (previewSound) 1f else 0f
     }
 
     // By default the preview returns to the channel that was playing full-screen and stays there
@@ -294,8 +368,9 @@ fun HomeScreen(
         screenResumed,
         recordingActive,
     ) {
-        if (!previewEnabled || !screenResumed || recordingActive || previewChannelId == null) {
-            previewController.stop()
+        if (!screenResumed) return@LaunchedEffect
+        if (!previewEnabled || recordingActive || previewChannelId == null) {
+            liveSession.stop()
             return@LaunchedEffect
         }
         val channel = if (previewChannelId == highlightedChannel?.id) {
@@ -303,11 +378,11 @@ fun HomeScreen(
         } else {
             graph.catalogRepository.channel(previewChannelId)
         } ?: highlightedChannel ?: run {
-            previewController.stop()
+            liveSession.stop()
             return@LaunchedEffect
         }
         val source = graph.sourceRepository.byId(channel.sourceId)
-        previewController.play(
+        liveSession.playPreview(
             PlayerController.Request(
                 url = channel.streamUrl,
                 title = channel.shownName,
@@ -318,7 +393,39 @@ fun HomeScreen(
         )
     }
 
-    Row(Modifier.fillMaxSize()) {
+    val guideBackEnabled = currentChannelId > 0L &&
+        channelMenu == null &&
+        recordTarget == null &&
+        pendingLiveChannel == null &&
+        !showBackgroundPrompt
+    fun returnToCurrentChannel() {
+        val visibleChannel = rows.asSequence()
+            .flatMap { sequenceOf(it.primary) + it.variants.asSequence() }
+            .firstOrNull { it.id == currentChannelId }
+        if (visibleChannel != null) {
+            requestLive(visibleChannel)
+        } else {
+            recordScope.launch {
+                graph.catalogRepository.channel(currentChannelId)?.let(::requestLive)
+            }
+        }
+    }
+
+    Row(
+        Modifier
+            .fillMaxSize()
+            // The app shell normally treats Back on Live TV as an exit request. Consume both
+            // event halves here and navigate on key-up so guide Back resumes the last watched
+            // channel without leaking into either MainScreen or the newly-opened PlayerScreen.
+            .onPreviewKeyEvent { event ->
+                if (guideBackEnabled && (event.key == Key.Back || event.key == Key.Escape)) {
+                    if (event.type == KeyEventType.KeyUp) returnToCurrentChannel()
+                    true
+                } else {
+                    false
+                }
+            },
+    ) {
 
         // ---- Category rail -----------------------------------------------------------------
         // Width animates to 0 while focus is in the guide (see onFocusRow) so the grid gets the
@@ -460,7 +567,7 @@ fun HomeScreen(
                     },
                     onRefresh = onRefresh,
                     onAddSource = onAddSource,
-                    previewPlayer = if (previewVisible) previewController.player else null,
+                    previewPlayer = if (previewVisible && screenResumed) previewController.player else null,
                     isRecording = highlightedRow?.primary?.id?.let { id ->
                         activeRecordings.any { it.channelId == id }
                     } == true,
@@ -469,12 +576,14 @@ fun HomeScreen(
                     canGoPrevDay = guideDayOffset > 0,
                     onPrevDay = { viewModel.nudgeGuideDay(-1) },
                     onNextDay = { viewModel.nudgeGuideDay(1) },
+                    watchFocusable = !awaitingGuideRowFocus,
                 )
                 // Shared by both layouts: focus follows the highlight and collapses the rail; LEFT
                 // from the leftmost element reopens the rail (consumed only when it was hidden).
                 val onFocusChannel: (ChannelsViewModel.Row) -> Unit = {
                     highlightedRow = it
                     railExpanded = false
+                    if (it.key == guideFocusTargetKey) awaitingGuideRowFocus = false
                 }
                 val onExitLeftChannel: () -> Boolean = {
                     if (!railExpanded) {
@@ -489,7 +598,16 @@ fun HomeScreen(
                     ChannelList(
                         rows = rows,
                         selectedKey = highlightedRow?.key,
-                        onSelectRow = { row -> channelMenu = row },
+                        focusRequestKey = guideFocusTargetKey,
+                        focusRequestId = guideFocusRequestId,
+                        onSelectRow = { row -> requestLive(row.primary) },
+                        onOpenRowOptions = { row ->
+                            armChannelMenuSelectGuard()
+                            channelMenu = row
+                        },
+                        onRowOptionsRelease = {
+                            releaseChannelMenuSelectGuardAfterEventTail()
+                        },
                         onFocusRow = onFocusChannel,
                         onToggleFavourite = { viewModel.toggleFavourite(it) },
                         onExitLeftFromChannel = onExitLeftChannel,
@@ -501,9 +619,18 @@ fun HomeScreen(
                         windowStartMillis = windowStart,
                         dayOffset = guideDayOffset,
                         selectedKey = highlightedRow?.key,
-                        // OK on a channel opens its menu: Watch, Record now, Schedule a later show,
-                        // Record series. The preview already follows the highlight as you browse.
-                        onSelectRow = { row -> channelMenu = row },
+                        focusRequestKey = guideFocusTargetKey,
+                        focusRequestId = guideFocusRequestId,
+                        // A short OK watches immediately. Hold OK for Watch/external/record options.
+                        // Programme blocks keep their separate record/schedule action dialog.
+                        onSelectRow = { row -> requestLive(row.primary) },
+                        onOpenRowOptions = { row ->
+                            armChannelMenuSelectGuard()
+                            channelMenu = row
+                        },
+                        onRowOptionsRelease = {
+                            releaseChannelMenuSelectGuardAfterEventTail()
+                        },
                         onFocusRow = onFocusChannel,
                         onProgramme = { row, programme -> recordTarget = row to programme },
                         onToggleFavourite = { viewModel.toggleFavourite(it) },
@@ -727,14 +854,45 @@ fun HomeScreen(
         val nowProg = menuRow.now
         val recordingThis = activeRecordings.firstOrNull { it.channelId == channel.id }
         val upcoming = menuRow.programmes.filter { it.startUtcMillis > nowMillis }.take(8)
-        Dialog(onDismissRequest = { channelMenu = null }) {
+        val heldPressFocusRequester = remember(menuRow.key) { FocusRequester() }
+        Dialog(
+            onDismissRequest = {
+                clearChannelMenuSelectGuard()
+                channelMenu = null
+            },
+        ) {
+            LaunchedEffect(menuRow.key) {
+                runCatching { heldPressFocusRequester.requestFocus() }
+            }
             Column(
                 Modifier
                     .width(480.dp)
+                    .onPreviewKeyEvent { event ->
+                        if (
+                            guardChannelMenuSelectUntilRelease &&
+                            event.key.isChannelMenuSelectKey()
+                        ) {
+                            if (event.type == KeyEventType.KeyUp) {
+                                releaseChannelMenuSelectGuardAfterEventTail()
+                            }
+                            true
+                        } else {
+                            false
+                        }
+                    }
                     .clip(RoundedCornerShape(16.dp))
                     .background(MaterialTheme.colorScheme.surface)
                     .padding(20.dp),
             ) {
+                // Own the remainder of the held press. Action rows stay disabled until the release
+                // guard drains, and focus remains here afterwards. The user must make a fresh
+                // directional choice before Select can activate Watch or another action.
+                Box(
+                    Modifier
+                        .size(1.dp)
+                        .focusRequester(heldPressFocusRequester)
+                        .focusable(),
+                )
                 Text(
                     channel.shownName,
                     style = MaterialTheme.typography.headlineSmall,
@@ -757,11 +915,17 @@ fun HomeScreen(
                     Modifier.heightIn(max = 420.dp).verticalScroll(rememberScrollState()),
                     verticalArrangement = Arrangement.spacedBy(2.dp),
                 ) {
-                    RecordActionRow(stringResource(R.string.guide_watch)) {
+                    RecordActionRow(
+                        stringResource(R.string.guide_watch),
+                        blockActivation = guardChannelMenuSelectUntilRelease,
+                    ) {
                         channelMenu = null
                         requestLive(channel)
                     }
-                    RecordActionRow(stringResource(R.string.guide_open_external)) {
+                    RecordActionRow(
+                        stringResource(R.string.guide_open_external),
+                        blockActivation = guardChannelMenuSelectUntilRelease,
+                    ) {
                         channelMenu = null
                         recordScope.launch {
                             val ua = graph.sourceRepository.byId(channel.sourceId)?.userAgent ?: "OpenTV/0.1 (Android)"
@@ -783,13 +947,21 @@ fun HomeScreen(
                         }
                     }
                     if (recordingThis != null) {
-                        RecordActionRow(stringResource(R.string.rec_stop_recording), primary = true) {
+                        RecordActionRow(
+                            stringResource(R.string.rec_stop_recording),
+                            primary = true,
+                            blockActivation = guardChannelMenuSelectUntilRelease,
+                        ) {
                             graph.recordingEngine.stop(recordingThis.id)
                             Toast.makeText(context, context.getString(R.string.rec_recording_stopped), Toast.LENGTH_SHORT).show()
                             channelMenu = null
                         }
                     } else {
-                        RecordActionRow(stringResource(R.string.guide_record_now_playing), primary = true) {
+                        RecordActionRow(
+                            stringResource(R.string.guide_record_now_playing),
+                            primary = true,
+                            blockActivation = guardChannelMenuSelectUntilRelease,
+                        ) {
                             recordScope.launch { graph.recordingEngine.startChannel(channel, nowProg) }
                             Toast.makeText(context, context.getString(R.string.rec_recording_started_see_tab, channel.shownName), Toast.LENGTH_LONG).show()
                             promptBackgroundIfNeeded()
@@ -797,7 +969,10 @@ fun HomeScreen(
                         }
                     }
                     if (nowProg != null) {
-                        RecordActionRow(stringResource(R.string.rec_record_series_named, nowProg.title)) {
+                        RecordActionRow(
+                            stringResource(R.string.rec_record_series_named, nowProg.title),
+                            blockActivation = guardChannelMenuSelectUntilRelease,
+                        ) {
                             recordScope.launch {
                                 graph.recordingEngine.recordSeries(channel, nowProg, menuRow.programmes)
                             }
@@ -815,7 +990,10 @@ fun HomeScreen(
                             modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                         )
                         upcoming.forEach { programme ->
-                            RecordActionRow("${formatTime(programme.startUtcMillis)}   ${programme.title}") {
+                            RecordActionRow(
+                                "${formatTime(programme.startUtcMillis)}   ${programme.title}",
+                                blockActivation = guardChannelMenuSelectUntilRelease,
+                            ) {
                                 // Open the programme dialog so the choice is record, remind or auto-switch —
                                 // not a surprise one-tap recording.
                                 channelMenu = null
@@ -823,7 +1001,10 @@ fun HomeScreen(
                             }
                         }
                     }
-                    RecordActionRow(stringResource(R.string.common_cancel)) { channelMenu = null }
+                    RecordActionRow(
+                        stringResource(R.string.common_cancel),
+                        blockActivation = guardChannelMenuSelectUntilRelease,
+                    ) { channelMenu = null }
                 }
             }
         }
@@ -839,6 +1020,9 @@ fun HomeScreen(
         )
     }
 }
+
+private fun Key.isChannelMenuSelectKey(): Boolean =
+    this == Key.DirectionCenter || this == Key.Enter || this == Key.NumPadEnter
 
 /** Inserts a reminder for a future programme and arms its alarm. No-op if one already exists. */
 private suspend fun setReminder(
@@ -865,7 +1049,12 @@ private suspend fun setReminder(
 }
 
 @Composable
-private fun RecordActionRow(label: String, primary: Boolean = false, onClick: () -> Unit) {
+private fun RecordActionRow(
+    label: String,
+    primary: Boolean = false,
+    blockActivation: Boolean = false,
+    onClick: () -> Unit,
+) {
     var focused by remember { mutableStateOf(false) }
     val bg = when {
         focused -> MaterialTheme.colorScheme.primary
@@ -888,7 +1077,10 @@ private fun RecordActionRow(label: String, primary: Boolean = false, onClick: ()
             .onFocusChanged { focused = it.isFocused }
             .clip(RoundedCornerShape(10.dp))
             .background(bg)
-            .clickable(onClick = onClick)
+            .clickable(
+                enabled = !blockActivation,
+                onClick = onClick,
+            )
             .padding(horizontal = 16.dp, vertical = 12.dp),
     )
 }
@@ -1137,6 +1329,7 @@ private fun EmptyState(onAddSource: () -> Unit) {
 }
 
 /** UTC in the database, device zone on screen. Converted here and nowhere else. */
+private const val CHANNEL_MENU_RELEASE_TAIL_MILLIS = 300L
 private val timeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
 
 private fun formatTime(utcMillis: Long): String = timeFormat.format(Date(utcMillis))

--- a/app/src/main/java/app/opentv/ui/player/PlayerScreen.kt
+++ b/app/src/main/java/app/opentv/ui/player/PlayerScreen.kt
@@ -7,7 +7,6 @@ package app.opentv.ui.player
 
 import android.view.ViewGroup
 import android.view.WindowManager
-import androidx.activity.compose.BackHandler
 import androidx.annotation.OptIn
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
@@ -104,6 +103,7 @@ import app.opentv.data.model.Channel
 import app.opentv.data.model.shownName
 import app.opentv.player.PlaybackQueue
 import app.opentv.player.PlayerController
+import app.opentv.player.LivePlaybackSession
 import app.opentv.ui.RecordingBackgroundDialog
 import app.opentv.ui.RecordingBackgroundPrompt
 import coil.compose.AsyncImage
@@ -139,14 +139,8 @@ fun PlayerScreen(
     val settings = remember { graph.settings }
     val scope = remember { CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate) }
     val subtitlesDefault by settings.subtitlesEnabled.collectAsState()
-    val controller = remember {
-        PlayerController(
-            context, scope, graph.streamingHttpClient,
-            subtitlesEnabled = settings.subtitlesEnabled.value,
-            // Opt-in shallow DVR so the transport's pause/rewind actually holds on a live stream.
-            dvr = settings.livePauseEnabled.value,
-        )
-    }
+    val liveSession = remember { graph.livePlaybackSession }
+    val controller = liveSession.controller
     val state by controller.state.collectAsState()
     val tracks by controller.tracks.collectAsState()
     // What's recording right now, so the Record button can show as armed for this channel.
@@ -157,13 +151,14 @@ fun PlayerScreen(
     // actually stops the system screensaver from firing mid-programme. keepScreenOn stays on too,
     // as a belt-and-braces backstop.
     DisposableEffect(Unit) {
+        liveSession.attach(LivePlaybackSession.Surface.PLAYER)
         val window = context.findActivity()?.window
         window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         view.keepScreenOn = true
         onDispose {
             window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
             view.keepScreenOn = false
-            controller.release()
+            liveSession.detach(LivePlaybackSession.Surface.PLAYER)
             scope.cancel()
         }
     }
@@ -224,7 +219,7 @@ fun PlayerScreen(
             val source = graph.sourceRepository.byId(channel.sourceId)
             // Xtream/M3U carry a ready URL; a Stalker channel's URL is minted here from its cmd.
             val url = graph.catalogRepository.resolvePlaybackUrl(channel, source)
-            controller.play(
+            liveSession.play(
                 PlayerController.Request(
                     url = url,
                     title = channel.shownName,
@@ -276,6 +271,12 @@ fun PlayerScreen(
         tuneTo(variants.firstOrNull { it.id == channel.id } ?: channel)
     }
 
+    // The guide suppresses captions in its small preview. Re-apply the full-screen preference even
+    // when the same prepared media item is handed over and its tracks therefore do not change.
+    LaunchedEffect(subtitlesDefault) {
+        if (subtitlesDefault) controller.setSubtitlesEnabled(true) else controller.disableText()
+    }
+
     // Sleep timer: when the armed deadline passes, stop and leave the player. Re-arming from
     // settings restarts this effect with the new deadline.
     val sleepDeadline by SleepTimer.deadline.collectAsState()
@@ -284,7 +285,7 @@ fun PlayerScreen(
         val wait = d - System.currentTimeMillis()
         if (wait > 0) delay(wait)
         SleepTimer.clear()
-        controller.stop()
+        liveSession.stop()
         onBack()
     }
 
@@ -319,22 +320,6 @@ fun PlayerScreen(
         }
     }
 
-    // Back steps back out one layer at a time — channel list, then picker, then the control bar —
-    // and only leaves the player once nothing is on screen. From immersive it's a single press out,
-    // so it never traps you, but it also no longer throws you all the way to the guide just because
-    // you wanted to dismiss the bar.
-    BackHandler {
-        when {
-            channelListVisible -> channelListVisible = false
-            panel != Panel.NONE -> panel = Panel.NONE
-            controlsVisible -> controlsVisible = false
-            else -> {
-                controller.stop()
-                onBack()
-            }
-        }
-    }
-
     // Number entry: once digits stop coming, jump to that channel number in the browsing list.
     LaunchedEffect(numberEntry) {
         if (numberEntry.isEmpty()) return@LaunchedEffect
@@ -360,11 +345,18 @@ fun PlayerScreen(
             .fillMaxSize()
             .background(Color.Black)
             .onPreviewKeyEvent { event ->
+                // Consume both halves of the TV remote's Back key here. Navigating on key-up keeps
+                // that same event from reaching MainScreen's exit handler during the transition.
+                if (event.key == Key.Back || event.key == Key.Escape) {
+                    if (event.type == KeyEventType.KeyUp) {
+                        liveSession.prepareHandoff(LivePlaybackSession.Surface.GUIDE)
+                        onBack()
+                    }
+                    return@onPreviewKeyEvent true
+                }
                 if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
                 val digit = keyToDigit(event.key)
                 when {
-                    // Never swallow Back/Escape — they must reach the back handler.
-                    event.key == Key.Back || event.key == Key.Escape -> false
                     // Typing a channel number jumps to it, TiviMate-style.
                     digit != null -> {
                         numberEntry = (numberEntry + digit).take(4)

--- a/app/src/main/java/app/opentv/ui/settings/AppSettingsScreen.kt
+++ b/app/src/main/java/app/opentv/ui/settings/AppSettingsScreen.kt
@@ -60,6 +60,7 @@ fun AppSettingsScreen(onBack: () -> Unit) {
     val settings = remember { AppSettings.get(context) }
     val themeMode by settings.themeMode.collectAsState()
     val channelLayout by settings.channelLayout.collectAsState()
+    val previewMode by settings.guidePreviewMode.collectAsState()
     val previewVideo by settings.guidePreviewVideo.collectAsState()
     val previewSound by settings.guidePreviewSound.collectAsState()
     val captions by settings.subtitlesEnabled.collectAsState()
@@ -175,6 +176,24 @@ fun AppSettingsScreen(onBack: () -> Unit) {
                 stringResource(R.string.settings_channel_layout_list),
                 channelLayout == AppSettings.ChannelLayout.LIST,
             ) { settings.setChannelLayout(AppSettings.ChannelLayout.LIST) }
+            Spacer(Modifier.height(8.dp))
+            Text(
+                stringResource(R.string.settings_preview_channel_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            ThemeOption(
+                stringResource(R.string.settings_preview_channel_current),
+                previewMode == AppSettings.GuidePreviewMode.CURRENT_CHANNEL,
+            ) { settings.setGuidePreviewMode(AppSettings.GuidePreviewMode.CURRENT_CHANNEL) }
+            ThemeOption(
+                stringResource(R.string.settings_preview_channel_highlighted),
+                previewMode == AppSettings.GuidePreviewMode.HIGHLIGHTED_CHANNEL,
+            ) { settings.setGuidePreviewMode(AppSettings.GuidePreviewMode.HIGHLIGHTED_CHANNEL) }
+            Text(
+                stringResource(R.string.settings_preview_channel_note),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
             Spacer(Modifier.height(8.dp))
             ToggleRow(
                 title = stringResource(R.string.settings_live_preview_title),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -184,8 +184,12 @@
     <string name="settings_channel_layout_title">Channel layout</string>
     <string name="settings_channel_layout_grid">Guide grid (with timeline)</string>
     <string name="settings_channel_layout_list">Simple list</string>
+    <string name="settings_preview_channel_title" translatable="false">Guide preview channel</string>
+    <string name="settings_preview_channel_current" translatable="false">Keep playing the current channel</string>
+    <string name="settings_preview_channel_highlighted" translatable="false">Follow the highlighted channel</string>
+    <string name="settings_preview_channel_note" translatable="false">Choose whether browsing leaves the channel you were watching in the preview pane or retunes the preview as you move through the guide.</string>
     <string name="settings_live_preview_title">Live preview in the guide</string>
-    <string name="settings_live_preview_subtitle">Play the selected channel in the preview pane. Turn this off if the guide stutters on an older box.</string>
+    <string name="settings_live_preview_subtitle">Play live TV in the preview pane. Turn this off if the guide stutters on an older box.</string>
     <string name="settings_preview_sound_title">Preview sound</string>
     <string name="settings_preview_sound_subtitle">Play the preview channel\'s audio too, not just the picture.</string>
     <string name="settings_section_playback">Playback</string>

--- a/app/src/test/java/app/opentv/GuideChannelActivationPolicyTest.kt
+++ b/app/src/test/java/app/opentv/GuideChannelActivationPolicyTest.kt
@@ -1,0 +1,45 @@
+/*
+ * This file is part of OpenTV.
+ * Copyright (C) 2026 The OpenTV Contributors
+ * Licensed under the GNU General Public License v3.0 or later.
+ */
+package app.opentv
+
+import app.opentv.ui.channels.GuideChannelActivationPolicy
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GuideChannelActivationPolicyTest {
+    @Test
+    fun shortPressWatchesImmediately() {
+        assertEquals(
+            GuideChannelActivationPolicy.Action.WATCH,
+            GuideChannelActivationPolicy.action(
+                heldMillis = GuideChannelActivationPolicy.LONG_PRESS_MILLIS - 1L,
+                systemReportedLongPress = false,
+            ),
+        )
+    }
+
+    @Test
+    fun thresholdPressOpensOptions() {
+        assertEquals(
+            GuideChannelActivationPolicy.Action.OPEN_OPTIONS,
+            GuideChannelActivationPolicy.action(
+                heldMillis = GuideChannelActivationPolicy.LONG_PRESS_MILLIS,
+                systemReportedLongPress = false,
+            ),
+        )
+    }
+
+    @Test
+    fun systemLongPressFlagOpensOptionsEvenBeforeThreshold() {
+        assertEquals(
+            GuideChannelActivationPolicy.Action.OPEN_OPTIONS,
+            GuideChannelActivationPolicy.action(
+                heldMillis = 100L,
+                systemReportedLongPress = true,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/app/opentv/GuideDirectionRepeatGateTest.kt
+++ b/app/src/test/java/app/opentv/GuideDirectionRepeatGateTest.kt
@@ -1,0 +1,74 @@
+/*
+ * This file is part of OpenTV.
+ * Copyright (C) 2026 The OpenTV Contributors
+ * Licensed under the GNU General Public License v3.0 or later.
+ */
+package app.opentv
+
+import app.opentv.ui.channels.GuideDirectionRepeatGate
+import app.opentv.ui.channels.GuideVerticalFocusBoundary
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GuideDirectionRepeatGateTest {
+    @Test
+    fun firstDirectionPressIsImmediate() {
+        val gate = GuideDirectionRepeatGate()
+
+        assertFalse(gate.shouldConsume(GuideDirectionRepeatGate.Direction.UP, 1_000L))
+    }
+
+    @Test
+    fun rapidSameDirectionRepeatsAreCoalesced() {
+        val gate = GuideDirectionRepeatGate(minimumIntervalMillis = 90L)
+
+        assertFalse(gate.shouldConsume(GuideDirectionRepeatGate.Direction.UP, 1_000L))
+        assertTrue(gate.shouldConsume(GuideDirectionRepeatGate.Direction.UP, 1_020L))
+        assertTrue(gate.shouldConsume(GuideDirectionRepeatGate.Direction.UP, 1_089L))
+        assertFalse(gate.shouldConsume(GuideDirectionRepeatGate.Direction.UP, 1_090L))
+    }
+
+    @Test
+    fun changingDirectionIsNeverDelayed() {
+        val gate = GuideDirectionRepeatGate(minimumIntervalMillis = 90L)
+
+        assertFalse(gate.shouldConsume(GuideDirectionRepeatGate.Direction.UP, 1_000L))
+        assertFalse(gate.shouldConsume(GuideDirectionRepeatGate.Direction.DOWN, 1_001L))
+        assertFalse(gate.shouldConsume(GuideDirectionRepeatGate.Direction.UP, 1_002L))
+    }
+
+    @Test
+    fun resetAllowsImmediateSameDirectionPress() {
+        val gate = GuideDirectionRepeatGate(minimumIntervalMillis = 90L)
+
+        assertFalse(gate.shouldConsume(GuideDirectionRepeatGate.Direction.UP, 1_000L))
+        gate.reset()
+        assertFalse(gate.shouldConsume(GuideDirectionRepeatGate.Direction.UP, 1_001L))
+    }
+
+    @Test
+    fun verticalBoundariesContainOnlyTheOutwardDirection() {
+        assertTrue(
+            GuideVerticalFocusBoundary.shouldConsume(
+                blockUp = true,
+                blockDown = false,
+                direction = GuideDirectionRepeatGate.Direction.UP,
+            ),
+        )
+        assertFalse(
+            GuideVerticalFocusBoundary.shouldConsume(
+                blockUp = true,
+                blockDown = false,
+                direction = GuideDirectionRepeatGate.Direction.DOWN,
+            ),
+        )
+        assertTrue(
+            GuideVerticalFocusBoundary.shouldConsume(
+                blockUp = false,
+                blockDown = true,
+                direction = GuideDirectionRepeatGate.Direction.DOWN,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/app/opentv/GuidePreviewPolicyTest.kt
+++ b/app/src/test/java/app/opentv/GuidePreviewPolicyTest.kt
@@ -94,4 +94,36 @@ class GuidePreviewPolicyTest {
             ),
         )
     }
+
+    @Test
+    fun guideReturnSelectsTheRowContainingTheCurrentChannel() {
+        assertEquals(
+            1,
+            GuidePreviewPolicy.returningRowIndex(
+                currentChannelId = 42L,
+                rowChannelIds = listOf(setOf(10L), setOf(42L), setOf(99L)),
+            ),
+        )
+    }
+
+    @Test
+    fun guideReturnRecognizesAQualityVariantInItsParentRow() {
+        assertEquals(
+            1,
+            GuidePreviewPolicy.returningRowIndex(
+                currentChannelId = 43L,
+                rowChannelIds = listOf(setOf(10L), setOf(42L, 43L), setOf(99L)),
+            ),
+        )
+    }
+
+    @Test
+    fun guideReturnHasNoTargetWhenCurrentChannelIsNotVisible() {
+        assertNull(
+            GuidePreviewPolicy.returningRowIndex(
+                currentChannelId = 42L,
+                rowChannelIds = listOf(setOf(10L), setOf(99L)),
+            ),
+        )
+    }
 }

--- a/app/src/test/java/app/opentv/GuidePreviewPolicyTest.kt
+++ b/app/src/test/java/app/opentv/GuidePreviewPolicyTest.kt
@@ -1,0 +1,97 @@
+/*
+ * This file is part of OpenTV.
+ * Copyright (C) 2026 The OpenTV Contributors
+ * Licensed under the GNU General Public License v3.0 or later.
+ */
+package app.opentv
+
+import app.opentv.core.AppSettings
+import app.opentv.ui.channels.GuidePreviewPolicy
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class GuidePreviewPolicyTest {
+    @Test
+    fun currentModeKeepsThePlayingChannel() {
+        assertEquals(
+            42L,
+            GuidePreviewPolicy.channelId(
+                AppSettings.GuidePreviewMode.CURRENT_CHANNEL,
+                currentChannelId = 42L,
+                highlightedChannelId = 99L,
+            ),
+        )
+    }
+
+    @Test
+    fun currentModeFallsBackToHighlightBeforeFirstPlayback() {
+        assertEquals(
+            99L,
+            GuidePreviewPolicy.channelId(
+                AppSettings.GuidePreviewMode.CURRENT_CHANNEL,
+                currentChannelId = 0L,
+                highlightedChannelId = 99L,
+            ),
+        )
+    }
+
+    @Test
+    fun highlightedModeFollowsBrowsing() {
+        assertEquals(
+            99L,
+            GuidePreviewPolicy.channelId(
+                AppSettings.GuidePreviewMode.HIGHLIGHTED_CHANNEL,
+                currentChannelId = 42L,
+                highlightedChannelId = 99L,
+            ),
+        )
+    }
+
+    @Test
+    fun noChannelIsChosenBeforePlaybackOrGuideData() {
+        assertNull(
+            GuidePreviewPolicy.channelId(
+                AppSettings.GuidePreviewMode.CURRENT_CHANNEL,
+                currentChannelId = 0L,
+                highlightedChannelId = null,
+            ),
+        )
+    }
+
+    @Test
+    fun watchOpensTheChannelShownInThePreview() {
+        assertEquals(
+            42L,
+            GuidePreviewPolicy.watchChannelId(
+                previewVisible = true,
+                previewChannelId = 42L,
+                highlightedChannelId = 99L,
+            ),
+        )
+    }
+
+    @Test
+    fun watchUsesHighlightWhenPreviewIsHidden() {
+        assertEquals(
+            99L,
+            GuidePreviewPolicy.watchChannelId(
+                previewVisible = false,
+                previewChannelId = 42L,
+                highlightedChannelId = 99L,
+            ),
+        )
+    }
+
+    @Test
+    fun watchFallsBackToHighlightWhilePreviewTargetIsUnavailable() {
+        assertEquals(
+            99L,
+            GuidePreviewPolicy.watchChannelId(
+                previewVisible = true,
+                previewChannelId = null,
+                highlightedChannelId = 99L,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/app/opentv/GuidePreviewPolicyTest.kt
+++ b/app/src/test/java/app/opentv/GuidePreviewPolicyTest.kt
@@ -60,42 +60,6 @@ class GuidePreviewPolicyTest {
     }
 
     @Test
-    fun watchOpensTheChannelShownInThePreview() {
-        assertEquals(
-            42L,
-            GuidePreviewPolicy.watchChannelId(
-                previewVisible = true,
-                previewChannelId = 42L,
-                highlightedChannelId = 99L,
-            ),
-        )
-    }
-
-    @Test
-    fun watchUsesHighlightWhenPreviewIsHidden() {
-        assertEquals(
-            99L,
-            GuidePreviewPolicy.watchChannelId(
-                previewVisible = false,
-                previewChannelId = 42L,
-                highlightedChannelId = 99L,
-            ),
-        )
-    }
-
-    @Test
-    fun watchFallsBackToHighlightWhilePreviewTargetIsUnavailable() {
-        assertEquals(
-            99L,
-            GuidePreviewPolicy.watchChannelId(
-                previewVisible = true,
-                previewChannelId = null,
-                highlightedChannelId = 99L,
-            ),
-        )
-    }
-
-    @Test
     fun guideReturnSelectsTheRowContainingTheCurrentChannel() {
         assertEquals(
             1,


### PR DESCRIPTION
## Summary

- Make one Back from full-screen live TV return directly to the guide, focused on the channel just watched; Back from the guide resumes that channel.
- Make a short Select on a channel row watch immediately, while a 500 ms hold opens the existing channel actions before release.
- Keep the held-Select release from activating Watch: actions stay disabled through the release tail and require a fresh directional choice.
- Keep programme/timeline selections on their existing programme-actions path.
- Add a state-aware Favourite / Remove favourite action to the held channel menu, sharing the guide's logical-channel favourite state.
- Remove the unfocused Record/Stop accent tint so it cannot be mistaken for the current selection.
- Make the guide header display-only: retain the live preview and programme details, but remove preview Watch/focus, date arrows/Today, and header record/refresh/add controls. Remote navigation stays in the channel rows and programme timeline.
- Share one live ExoPlayer session between the guide preview and full-screen player so same-stream transitions reuse the prepared media item, decoder, and buffer instead of reopening the URL.
- Stop the shared session when leaving Live TV for an unrelated tab or destination so audio cannot leak.
- Coalesce rapid same-direction Up/Down events to a 90 ms minimum interval, while accepting the first press and direction changes immediately.
- Keep vertical focus inside the first/last guide rows and category entries instead of allowing a held direction to escape into the outer app navigation rail.
- Make LEFT-to-category-rail navigation a confirmed handoff: scroll the selected category into composition, retry focus after layout, and consume LEFT until the inner rail reports focus.

## Motivation

Android TV channel browsing should be usable with one remote press per action. The previous flow required repeated Back presses, opened a menu for every channel selection, and restarted the same stream when moving between the guide preview and full-screen playback.

Physical remote testing also exposed two navigation failures during long Up holds. Rapid repeats could accumulate UI work, and default spatial focus search could leave the guide at its vertical edge. A subsequent direction then navigated the outer OpenTV/Live TV/Recordings rail. The category-rail opener additionally used a one-shot 50 ms focus request whose failure was silently ignored. The repeat gate, explicit boundaries, and focus-confirmed handoff address these paths without changing programme actions or playback policy.

## Testing

- `./gradlew test lintVitalRelease assembleRelease`
- Debug and release unit suites passed, including repeat coalescing, immediate direction changes, reset behavior, and outward-boundary regression tests.
- Release-critical lint, R8, resource shrinking, and APK packaging passed.
- The equivalent production patch was tested on an NVIDIA Shield: guide → full-screen and full-screen → guide reused the existing live session; the guide preview remained visible and audible; leaving Live TV stopped its audio; native Android PiP and restoration still worked.
- Remote tests covered short Select, held Select opening while still pressed, release leaving the menu open, fresh directional focus, timeline actions, and one-Back navigation.
- The held-navigation update was verified on the Shield with a physical hold-Up-to-the-first-channel test, two more seconds of holding, release, Down, then Left. Focus stayed in the guide and Left opened the inner Live TV category rail rather than the outer app rail.

## Stack

This is stacked on #6 (`Keep the current channel playing in the guide preview`). Until #6 lands, GitHub will show those prerequisite changes in this PR too. The navigation/shared-player work is commit `b570e38`; the held-navigation stability follow-up is `59344d6`; the favourite action, menu-focus styling, and display-only header follow in `78c425e`, `bee5710`, and `753f103`. After #6 merges, this PR can be rebased so only the navigation, guide UI, and shared-player changes remain.

No provider credentials, URLs, Shield button automation, SmartTube/Netflix behavior, custom version branding, or commercial diagnostics are included. Upstream `0.11.8` version metadata is unchanged.
